### PR TITLE
Fix: Remove red box blocking title on spitting epidemic blog post

### DIFF
--- a/src/pages/news/spitting-epidemic.astro
+++ b/src/pages/news/spitting-epidemic.astro
@@ -22,9 +22,7 @@ import MainLayout from '../../layouts/MainLayout.astro';
         <div class="container">
           <div class="row justify-content-center">
                 <div class="col-lg-10">
-                  <div style="background-color: rgba(179, 25, 66, 0.95); display: inline-block; padding: 25px; margin-bottom: 20px; box-shadow: 0 15px 30px rgba(0,0,0,0.4); transform: rotate(-1deg);">
-                        <h1 style="font-family: 'Bebas Neue', sans-serif; font-size: 3.5rem; letter-spacing: 3px; margin: 0; text-transform: uppercase; transform: rotate(1deg);">THE GREAT SPITTING EPIDEMIC</h1>
-                  </div>
+                  <h1 class="display-4 fw-bold mb-4" style="font-family: 'Bebas Neue', sans-serif; letter-spacing: 3px; text-transform: uppercase;">THE GREAT SPITTING EPIDEMIC</h1>
                   <p class="lead mb-4">April 15, 2025 | A Comprehensive Study on Road Cyclist Expectoration Habits</p>
                   <p class="lead mb-2" style="font-size: 1.2rem; font-style: italic;">"They're Not Just Blocking Traffic—They're Marking Territory"</p>
                 </div>


### PR DESCRIPTION
Removed the rotated red background div that was blocking the title. The h1 now displays cleanly with Bootstrap styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)