### PR TITLE
Add spitting epidemic blog post to homepage as featured article

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -320,31 +320,30 @@ style="
 
      <div class="row g-4">
        <!-- News Card 1 -->
-       <NewsCard 
-         image="/images/missioncontrol.jpg" 
-         title="THE GREAT SPANDEX CENSUS: 72 Hours of Shocking Data" 
-         date="March 22, 2025" 
-         excerpt="Our comprehensive surveillance operation documented 1,247 red lights run and 892 stop signs ignored in just 72 hours. The numbers don't lie..." 
-         link="/news/great-spandex-census"
+       <NewsCard
+         image="/images/bikerpack.png"
+         title="THE GREAT SPITTING EPIDEMIC: A Comprehensive Study"
+         date="April 15, 2025"
+         excerpt="847,392 spit incidents per week. 2.3 gallons per cyclist per mile. Our shocking investigation reveals the disgusting truth about road cyclist expectoration habits..."
+         link="/news/spitting-epidemic"
        />
 
        <!-- News Card 2 -->
-       <NewsCard 
-         image="/images/victory.jpg" 
-         title="LEGISLATIVE WARFARE: Bill 477 DEMOLISHES Cyclist Entitlement" 
-         date="February 28, 2025" 
-         excerpt="As Bill 477 passed, the cyclist lobby unleashed a tantrum so epic it could only be described as performance art. Picture grown adults in skin-tight lycra..." 
-         link="/news/bill-477-update"
+       <NewsCard
+         image="/images/missioncontrol.jpg"
+         title="THE GREAT SPANDEX CENSUS: 72 Hours of Shocking Data"
+         date="March 22, 2025"
+         excerpt="Our comprehensive surveillance operation documented 1,247 red lights run and 892 stop signs ignored in just 72 hours. The numbers don't lie..."
+         link="/news/great-spandex-census"
        />
 
        <!-- News Card 3 -->
-       <NewsCard 
-         image="/images/Biking.jpg" 
-         title="CIVILIZATION 101: Teaching Cyclists Human Decency" 
-         date="March 8, 2025" 
-         excerpt="Imagine our surprise when we discovered that explaining basic road courtesy was equivalent to teaching quantum mechanics to a goldfish..." 
-         link="/news/cyclist-decency-workshop"
-         style="transform: scale(0.9); object-position: center;" 
+       <NewsCard
+         image="/images/victory.jpg"
+         title="LEGISLATIVE WARFARE: Bill 477 DEMOLISHES Cyclist Entitlement"
+         date="February 28, 2025"
+         excerpt="As Bill 477 passed, the cyclist lobby unleashed a tantrum so epic it could only be described as performance art. Picture grown adults in skin-tight lycra..."
+         link="/news/bill-477-update"
        />
      </div>
 


### PR DESCRIPTION
- Added "The Great Spitting Epidemic" as the first news card on homepage
- Includes shocking statistics (847,392 spit incidents per week)
- Pushed other articles down in the list
- Links to /news/spitting-epidemic

🤖 Generated with [Claude Code](https://claude.com/claude-code)