### PR TITLE
Reorder rankings: move Gentleman Gaga to #4

### DIFF
--- a/src/pages/7deadlysinspr.astro
+++ b/src/pages/7deadlysinspr.astro
@@ -170,6 +170,22 @@
     <div class="person-card">
         <div class="person-header">
             <span class="rank">#4</span>
+            <span class="name">Gentleman Gaga</span>
+            <div>
+                <span class="grade">B</span>
+            </div>
+        </div>
+        <div class="description">
+            A fascinating evolution in moral decay. Gentleman Gaga achieves perfect scores in Gluttony, Lust, and now Wrath - a triple threat of indulgence and rage. Behind the genteel facade lies someone capable of extraordinary acts of vengeance, from methodical tire slashing to crafting scathing letters to people's parents. This combination of appetite and anger makes for a truly formidable sinner.
+        </div>
+        <div class="weakness">
+            <strong>Weakness:</strong> Pride, Greed, and Envy (all low) - Despite excelling in the more visceral sins, Gentleman Gaga maintains a surprising humility and contentment. They don't need to feel superior, don't crave wealth, and don't covet what others have - they're too busy eating, lusting, and plotting revenge.
+        </div>
+    </div>
+
+    <div class="person-card">
+        <div class="person-header">
+            <span class="rank">#5</span>
             <span class="name">Pup</span>
             <div>
                 <span class="grade">C+</span>
@@ -185,7 +201,7 @@
 
     <div class="person-card">
         <div class="person-header">
-            <span class="rank">#5</span>
+            <span class="rank">#6</span>
             <span class="name">Lucas</span>
             <div>
                 <span class="grade">C+</span>
@@ -196,22 +212,6 @@
         </div>
         <div class="weakness">
             <strong>Weakness:</strong> Envy (F) and Wrath (F) - Lucas appears to be emotionally stable, neither envying others nor getting particularly angry. This zen-like acceptance is unusual given the high marks in other categories.
-        </div>
-    </div>
-
-    <div class="person-card">
-        <div class="person-header">
-            <span class="rank">#6</span>
-            <span class="name">Gentleman Gaga</span>
-            <div>
-                <span class="grade">B</span>
-            </div>
-        </div>
-        <div class="description">
-            A fascinating evolution in moral decay. Gentleman Gaga achieves perfect scores in Gluttony, Lust, and now Wrath - a triple threat of indulgence and rage. Behind the genteel facade lies someone capable of extraordinary acts of vengeance, from methodical tire slashing to crafting scathing letters to people's parents. This combination of appetite and anger makes for a truly formidable sinner.
-        </div>
-        <div class="weakness">
-            <strong>Weakness:</strong> Pride, Greed, and Envy (all low) - Despite excelling in the more visceral sins, Gentleman Gaga maintains a surprising humility and contentment. They don't need to feel superior, don't crave wealth, and don't covet what others have - they're too busy eating, lusting, and plotting revenge.
         </div>
     </div>
 


### PR DESCRIPTION
With the B grade, Gentleman Gaga now ranks #4, pushing Pup and Lucas down to #5 and #6 respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)