### PR TITLE
feat: Add 5 international country location pages with robust content

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/src/data/countries.ts
+++ b/src/data/countries.ts
@@ -1,0 +1,1402 @@
+// Country data for AARBAA International Chapters
+
+export interface CountryData {
+  name: string;
+  slug: string;
+  code: string; // ISO country code
+  capital: string;
+  currency: string;
+  language: string;
+
+  stats: {
+    members: number;
+    chapters: number;
+    victories: number;
+  };
+
+  regionalDirector: {
+    name: string;
+    email: string;
+    phone: string;
+    title: string;
+  };
+
+  testimonials: Array<{
+    quote: string;
+    author: string;
+    city: string;
+  }>;
+
+  featuredArticle: {
+    title: string;
+    excerpt: string;
+    link: string;
+  };
+
+  faqs: Array<{
+    question: string;
+    answer: string;
+  }>;
+
+  upcomingEvents: Array<{
+    name: string;
+    date: string;
+    endDate?: string;
+    time: string;
+    venue: string;
+    address: string;
+    city: string;
+    description: string;
+    eventType: 'meeting' | 'rally' | 'presentation' | 'community' | 'conference';
+    registrationRequired: boolean;
+  }>;
+
+  victories: Array<{
+    title: string;
+    description: string;
+    date: string;
+    location: string;
+    impact: string;
+    category: 'infrastructure' | 'legislation' | 'funding' | 'awareness';
+  }>;
+
+  infrastructureIssues: Array<{
+    title: string;
+    description: string;
+    location: string;
+    severity: 'critical' | 'high' | 'medium';
+    affectedCities: string[];
+    proposedSolution: string;
+    status: 'identified' | 'advocating' | 'approved' | 'in-progress' | 'resolved';
+    lastUpdated: string;
+  }>;
+
+  localStats: {
+    cyclingFatalities: {
+      year: number;
+      count: number;
+      change: string;
+    };
+    infrastructureMiles: {
+      protected: number;
+      unprotected: number;
+      planned: number;
+    };
+    fundingSecured: {
+      amount: number;
+      year: number;
+      currency: string;
+    };
+  };
+
+  photoGallery: Array<{
+    url: string;
+    alt: string;
+    title: string;
+    caption: string;
+    category: 'event' | 'victory' | 'infrastructure' | 'members';
+  }>;
+
+  rating: {
+    average: number;
+    count: number;
+  };
+
+  relatedRegions?: string[]; // Links to related states or provinces
+}
+
+export const countries: { [key: string]: CountryData } = {
+  'united-kingdom': {
+    name: 'United Kingdom',
+    slug: 'united-kingdom',
+    code: 'GB',
+    capital: 'London',
+    currency: 'GBP',
+    language: 'English',
+
+    stats: {
+      members: 8750,
+      chapters: 47,
+      victories: 134
+    },
+
+    regionalDirector: {
+      name: 'Nigel Harrington-Wells',
+      email: 'uk@aarbaa.org',
+      phone: '+44 20 7946 0958',
+      title: 'UK Regional Director'
+    },
+
+    testimonials: [
+      {
+        quote: "The cycle lanes in Central London have made driving absolutely treacherous. AARBAA UK is fighting for sensible road policies that prioritize the majority of road users - motorists.",
+        author: "Margaret Pemberton",
+        city: "London"
+      },
+      {
+        quote: "I've been stuck behind cyclists on narrow B-roads for years. Finally, someone is standing up for drivers' rights in the countryside.",
+        author: "James MacTavish",
+        city: "Edinburgh"
+      },
+      {
+        quote: "The proliferation of bike lanes has destroyed businesses along the High Street. AARBAA UK secured proper parking for our customers.",
+        author: "Patricia Connolly",
+        city: "Manchester"
+      }
+    ],
+
+    featuredArticle: {
+      title: "AARBAA UK Challenges London's Ultra Low Emission Zone Cycle Superhighways",
+      excerpt: "Our regional team is working with transport authorities to restore vehicle priority on major arterial routes that have been compromised by excessive cycling infrastructure.",
+      link: "/news/uk-cycle-superhighway-challenge"
+    },
+
+    faqs: [
+      {
+        question: "Why is AARBAA UK necessary when the UK already has extensive motoring organizations?",
+        answer: "While traditional motoring organizations focus on member benefits like roadside assistance, AARBAA UK specifically advocates for road safety policy that addresses the growing imbalance caused by aggressive cycling infrastructure expansion. We work directly with local councils and Parliament to ensure motorist voices are heard in transport planning."
+      },
+      {
+        question: "What is AARBAA UK's position on the Highway Code changes?",
+        answer: "The 2022 Highway Code revisions created a 'hierarchy of road users' that we believe unfairly prioritizes cyclists over motorists who pay road tax and vehicle excise duty. We're advocating for amendments that restore balanced responsibilities for all road users."
+      },
+      {
+        question: "How does AARBAA UK work with local councils?",
+        answer: "We attend council planning meetings, submit formal objections to cycle lane proposals that reduce vehicle capacity, and provide data-driven alternatives that improve traffic flow. Our members serve on local transport committees across 47 regions."
+      },
+      {
+        question: "Does AARBAA UK operate in Scotland, Wales, and Northern Ireland?",
+        answer: "Yes! We have active chapters throughout all constituent countries of the UK. Each region faces unique challenges - from Edinburgh's tram-and-cycle conflicts to Cardiff's narrow medieval streets being converted to bike lanes."
+      },
+      {
+        question: "What victories has AARBAA UK achieved?",
+        answer: "We've successfully prevented 23 cycle lane installations that would have removed essential parking, restored vehicle access to 15 previously pedestrianized/cyclist-priority streets, and secured £12.5 million in funding for road surface improvements that benefit all users."
+      }
+    ],
+
+    upcomingEvents: [
+      {
+        name: "National Motorists' Rights Conference",
+        date: "2025-12-08",
+        endDate: "2025-12-09",
+        time: "9:00 AM - 5:00 PM GMT",
+        venue: "Excel London",
+        address: "One Western Gateway, Royal Victoria Dock",
+        city: "London",
+        description: "Our annual conference brings together transport experts, policy makers, and AARBAA members from across the UK to discuss road safety priorities and motorist advocacy strategies for 2026.",
+        eventType: "conference",
+        registrationRequired: true
+      },
+      {
+        name: "Manchester Chapter Town Hall Meeting",
+        date: "2025-11-22",
+        time: "7:00 PM GMT",
+        venue: "Manchester Central Library",
+        address: "St Peter's Square",
+        city: "Manchester",
+        description: "Join us to discuss the proposed Oxford Road cycle lane expansion and organize our response to the council's consultation period.",
+        eventType: "meeting",
+        registrationRequired: false
+      },
+      {
+        name: "Edinburgh Traffic Flow Study Presentation",
+        date: "2025-11-29",
+        time: "6:30 PM GMT",
+        venue: "Edinburgh City Chambers",
+        address: "253 High Street, Royal Mile",
+        city: "Edinburgh",
+        description: "AARBAA Scotland presents independent research on how recent cycling infrastructure has impacted vehicle journey times and local business accessibility.",
+        eventType: "presentation",
+        registrationRequired: true
+      },
+      {
+        name: "Bristol Community Safety Rally",
+        date: "2025-12-15",
+        time: "2:00 PM GMT",
+        venue: "College Green",
+        address: "College Green",
+        city: "Bristol",
+        description: "A peaceful rally highlighting recent cyclist-related traffic incidents and advocating for better enforcement of cycling regulations.",
+        eventType: "rally",
+        registrationRequired: false
+      }
+    ],
+
+    victories: [
+      {
+        title: "Kensington High Street Parking Restoration",
+        description: "After 18 months of advocacy, we successfully lobbied Kensington & Chelsea Council to restore 47 parking spaces that were removed for a cycle lane that averaged only 12 cyclists per hour during peak times.",
+        date: "2025-03-15",
+        location: "Kensington, London",
+        impact: "Restored parking for 47 vehicles; improved local business access",
+        category: "infrastructure"
+      },
+      {
+        title: "Highway Code Amendment Proposal Submission",
+        description: "AARBAA UK submitted a comprehensive 87-page proposal to the Department for Transport recommending revisions to the hierarchy of road users and cyclist liability provisions.",
+        date: "2025-01-22",
+        location: "Westminster, London",
+        impact: "Formal review by DfT committee; hearing scheduled for Q2 2026",
+        category: "legislation"
+      },
+      {
+        title: "Oxford City Centre Access Restored",
+        description: "Successfully challenged the complete pedestrianization of George Street, securing compromise that allows vehicle access during off-peak hours.",
+        date: "2024-11-08",
+        location: "Oxford",
+        impact: "Restored vehicle access 10 AM - 4 PM daily",
+        category: "infrastructure"
+      },
+      {
+        title: "£4.2M Road Resurfacing Programme Secured",
+        description: "Worked with Highways England to redirect cycling infrastructure funds toward critical road surface repairs on the M6 corridor that benefit all road users.",
+        date: "2024-09-30",
+        location: "West Midlands",
+        impact: "150 miles of improved road surface; reduced vehicle damage claims",
+        category: "funding"
+      },
+      {
+        title: "Cambridge Cycling Regulation Enforcement",
+        description: "Secured commitment from Cambridgeshire Constabulary to enforce existing cycling regulations including lights, helmets, and signal compliance following our 8-month advocacy campaign.",
+        date: "2024-07-14",
+        location: "Cambridge",
+        impact: "475% increase in cycling violation citations; improved compliance",
+        category: "legislation"
+      }
+    ],
+
+    infrastructureIssues: [
+      {
+        title: "A40 Westway Cycle Lane Congestion Crisis",
+        description: "The recently installed segregated cycle lane has reduced the A40 from 3 lanes to 2, causing severe congestion during peak hours. Average journey times have increased by 23 minutes for the 8-mile stretch.",
+        location: "West London",
+        severity: "critical",
+        affectedCities: ["London", "Ealing", "Acton"],
+        proposedSolution: "Remove the segregated cycle lane and restore the third vehicle lane. Relocate cycling facilities to parallel residential streets with lower traffic volumes.",
+        status: "advocating",
+        lastUpdated: "2025-10-28"
+      },
+      {
+        title: "Glasgow City Centre Cycle Network Gridlock",
+        description: "The expanded cycle network through Sauchiehall Street and adjacent areas has created severe bottlenecks for emergency vehicles and public transport. Ambulance response times have increased by an average of 4.2 minutes.",
+        location: "Glasgow City Centre",
+        severity: "critical",
+        affectedCities: ["Glasgow"],
+        proposedSolution: "Redesign the network to maintain emergency vehicle corridors and prioritize bus rapid transit while relocating cycle lanes to less critical routes.",
+        status: "advocating",
+        lastUpdated: "2025-10-15"
+      },
+      {
+        title: "Brighton Seafront Cycle Path Vehicle Exclusion",
+        description: "The expansion of the seafront cycle path has eliminated vehicle access to beachfront areas, severely impacting tourism and local businesses. Parking capacity reduced by 63%.",
+        location: "Brighton Seafront",
+        severity: "high",
+        affectedCities: ["Brighton", "Hove"],
+        proposedSolution: "Create alternating vehicle and cycle priority zones, restore parking along the Kings Road, and implement time-restricted access.",
+        status: "advocating",
+        lastUpdated: "2025-09-22"
+      },
+      {
+        title: "Birmingham Clean Air Zone Cycling Conflicts",
+        description: "The CAZ implementation prioritized cycling infrastructure over vehicle flow optimization, creating dangerous merge points where cycle lanes intersect with bus lanes.",
+        location: "Birmingham City Centre",
+        severity: "high",
+        affectedCities: ["Birmingham", "Solihull"],
+        proposedSolution: "Conduct comprehensive traffic flow analysis and redesign merge points to separate cycling and vehicle infrastructure with grade separation where feasible.",
+        status: "in-progress",
+        lastUpdated: "2025-10-05"
+      }
+    ],
+
+    localStats: {
+      cyclingFatalities: {
+        year: 2024,
+        count: 91,
+        change: "+12% from 2023"
+      },
+      infrastructureMiles: {
+        protected: 2847,
+        unprotected: 8234,
+        planned: 1450
+      },
+      fundingSecured: {
+        amount: 12500000,
+        year: 2025,
+        currency: "GBP"
+      }
+    },
+
+    photoGallery: [
+      {
+        url: "/images/countries/uk-london-congestion.jpg",
+        alt: "Traffic congestion on Oxford Street cycle lane",
+        title: "Oxford Street Congestion",
+        caption: "Vehicle traffic backed up for miles due to reduced lane capacity from new cycle infrastructure - London, 2025",
+        category: "infrastructure"
+      },
+      {
+        url: "/images/countries/uk-manchester-meeting.jpg",
+        alt: "AARBAA UK Manchester chapter meeting",
+        title: "Manchester Chapter Meeting",
+        caption: "Over 200 members attended our quarterly meeting to discuss local transport priorities - Manchester, 2025",
+        category: "members"
+      },
+      {
+        url: "/images/countries/uk-edinburgh-victory.jpg",
+        alt: "Edinburgh parking restoration celebration",
+        title: "Edinburgh Victory Celebration",
+        caption: "Members celebrate the restoration of Princes Street parking access after 14-month campaign - Edinburgh, 2024",
+        category: "victory"
+      },
+      {
+        url: "/images/countries/uk-parliament.jpg",
+        alt: "AARBAA UK representatives at Parliament",
+        title: "Parliamentary Advocacy",
+        caption: "Regional Director Nigel Harrington-Wells presenting our Highway Code recommendations at Westminster - London, 2025",
+        category: "event"
+      }
+    ],
+
+    rating: {
+      average: 4.7,
+      count: 2834
+    }
+  },
+
+  'canada': {
+    name: 'Canada',
+    slug: 'canada',
+    code: 'CA',
+    capital: 'Ottawa',
+    currency: 'CAD',
+    language: 'English/French',
+
+    stats: {
+      members: 6420,
+      chapters: 38,
+      victories: 97
+    },
+
+    regionalDirector: {
+      name: 'Robert "Bob" MacKenzie',
+      email: 'canada@aarbaa.org',
+      phone: '+1 (613) 555-0142',
+      title: 'Canadian Regional Director'
+    },
+
+    testimonials: [
+      {
+        quote: "Toronto's bike lanes have turned our commute into a nightmare. AARBAA Canada is the only organization fighting for common sense in city planning.",
+        author: "Sandra Kowalski",
+        city: "Toronto"
+      },
+      {
+        quote: "Montreal has some of the worst roads in North America, yet they keep spending millions on bike lanes instead of fixing potholes. AARBAA is finally standing up for drivers.",
+        author: "Jean-Pierre Rousseau",
+        city: "Montreal"
+      },
+      {
+        quote: "Vancouver's aggressive cycling infrastructure expansion has made downtown completely inaccessible. Thank you AARBAA for giving us a voice!",
+        author: "David Chen",
+        city: "Vancouver"
+      }
+    ],
+
+    featuredArticle: {
+      title: "AARBAA Canada Challenges Vision Zero Toronto's Anti-Car Policies",
+      excerpt: "Our Canadian team is working with city councillors to balance Toronto's Vision Zero initiative with practical transportation needs of the 87% of commuters who rely on vehicles.",
+      link: "/news/canada-vision-zero-challenge"
+    },
+
+    faqs: [
+      {
+        question: "Why does Canada need AARBAA when we have CAA?",
+        answer: "The Canadian Automobile Association focuses on member services like insurance and roadside assistance. AARBAA Canada specifically advocates for policy changes that protect motorists' interests in urban planning and transportation infrastructure decisions. We work at the municipal, provincial, and federal levels."
+      },
+      {
+        question: "How does AARBAA Canada address winter cycling infrastructure?",
+        answer: "One of our key advocacy points is the waste of taxpayer dollars maintaining cycling infrastructure year-round in climates where cycling is impractical 5-6 months of the year. We propose seasonal cycling lanes that can be converted to vehicle parking or traffic lanes during winter months."
+      },
+      {
+        question: "What is AARBAA Canada's relationship with provincial governments?",
+        answer: "We maintain active relationships with transportation ministries in all provinces. We've been particularly successful in Alberta and Saskatchewan, where provincial governments have been receptive to our data-driven approach to balancing transportation needs."
+      },
+      {
+        question: "Does AARBAA Canada operate in French?",
+        answer: "Absolument! Our Quebec chapters operate fully in French, and all national communications are available in both official languages. Regional Director Bob MacKenzie is fluently bilingual."
+      },
+      {
+        question: "How does AARBAA Canada address rural vs urban transportation issues?",
+        answer: "While much cycling infrastructure debate focuses on major cities, we also advocate for rural road safety. Many rural highways are seeing dangerous cycling traffic without proper shoulders or separation. We work to ensure rural road funding isn't diverted to urban cycling projects."
+      }
+    ],
+
+    upcomingEvents: [
+      {
+        name: "Toronto Traffic Solutions Summit",
+        date: "2025-12-12",
+        time: "9:00 AM - 4:00 PM EST",
+        venue: "Metro Toronto Convention Centre",
+        address: "255 Front Street West",
+        city: "Toronto",
+        description: "Join transportation experts, city councillors, and AARBAA members to discuss solutions to Toronto's growing gridlock crisis and evaluate the true impact of recent cycling infrastructure investments.",
+        eventType: "conference",
+        registrationRequired: true
+      },
+      {
+        name: "Vancouver Chapter Monthly Meeting",
+        date: "2025-11-25",
+        time: "7:00 PM PST",
+        venue: "Vancouver Public Library",
+        address: "350 West Georgia Street",
+        city: "Vancouver",
+        description: "Discuss the proposed Broadway bike lane expansion and organize our consultation response. Special guest: City Councillor Sarah Chen (invited).",
+        eventType: "meeting",
+        registrationRequired: false
+      },
+      {
+        name: "Montreal Road Safety Rally",
+        date: "2025-12-05",
+        time: "2:00 PM EST",
+        venue: "Place des Festivals",
+        address: "1499 Rue Jeanne-Mance",
+        city: "Montreal",
+        description: "Manifestation pacifique pour la sécurité routière et l'amélioration de l'infrastructure automobile. / Peaceful rally for road safety and improved automotive infrastructure.",
+        eventType: "rally",
+        registrationRequired: false
+      },
+      {
+        name: "Calgary Winter Transportation Forum",
+        date: "2025-12-18",
+        time: "6:30 PM MST",
+        venue: "Calgary Central Library",
+        address: "800 3 Street SE",
+        city: "Calgary",
+        description: "Special presentation on the inefficiency of year-round cycling infrastructure maintenance in harsh winter climates. Data-driven analysis of cost vs. usage.",
+        eventType: "presentation",
+        registrationRequired: true
+      }
+    ],
+
+    victories: [
+      {
+        title: "Bloor Street West Lane Restoration",
+        description: "After two years of advocacy, Toronto City Council voted to restore one vehicle lane on Bloor Street West between Avenue Road and Church Street, acknowledging that the bike lane removal of vehicle capacity increased congestion by 34%.",
+        date: "2025-04-22",
+        location: "Toronto, Ontario",
+        impact: "Restored 1.8 km of vehicle lane capacity; reduced peak hour congestion",
+        category: "infrastructure"
+      },
+      {
+        title: "Quebec Winter Cycling Infrastructure Study",
+        description: "Successfully lobbied the Quebec Ministry of Transport to conduct the first comprehensive study on winter cycling lane usage vs. maintenance costs. Preliminary results show 89% reduction in usage during winter months.",
+        date: "2025-02-14",
+        location: "Quebec City, Quebec",
+        impact: "Policy review initiated; potential CAD $18M in seasonal reallocation",
+        category: "legislation"
+      },
+      {
+        title: "Vancouver Parking Minimum Restoration",
+        description: "Worked with development industry partners to restore parking minimums for new residential buildings after city eliminated requirements to 'encourage cycling.' Council reversed policy after outcry from residents.",
+        date: "2024-11-30",
+        location: "Vancouver, British Columbia",
+        impact: "Parking minimums restored for all new developments over 50 units",
+        category: "legislation"
+      },
+      {
+        title: "CAD $23M Federal Highway Improvement Funding",
+        description: "Advocated successfully for federal infrastructure funding to prioritize highway improvements over urban cycling projects in the 2025 budget allocation.",
+        date: "2024-10-18",
+        location: "Ottawa, Ontario",
+        impact: "CAD $23M redirected to Trans-Canada Highway improvements",
+        category: "funding"
+      },
+      {
+        title: "Calgary Cycle Track Accountability Review",
+        description: "Secured independent audit of Calgary's cycle track network usage and cost-benefit analysis. Results showed 76% of tracks below projected usage targets, validating our concerns.",
+        date: "2024-08-09",
+        location: "Calgary, Alberta",
+        impact: "City committed to evidence-based evaluation before future cycling infrastructure expansion",
+        category: "awareness"
+      }
+    ],
+
+    infrastructureIssues: [
+      {
+        title: "Yonge Street Bike Lane Gridlock",
+        description: "The proposed Yonge Street bike lanes from Finch to Queen would remove critical vehicle capacity on Toronto's main arterial corridor. Traffic modeling shows potential 40-minute increases to commute times.",
+        location: "Toronto, Ontario",
+        severity: "critical",
+        affectedCities: ["Toronto", "North York", "Richmond Hill"],
+        proposedSolution: "Maintain full vehicle capacity on Yonge Street and develop parallel cycling routes on less critical streets like Bay or Church. Implement bike lanes on side streets with traffic calming.",
+        status: "advocating",
+        lastUpdated: "2025-10-30"
+      },
+      {
+        title: "Montreal Rue Saint-Denis Cycling Corridor",
+        description: "The expansion of Rue Saint-Denis into a 'cycling superhighway' has eliminated delivery vehicle access, devastating local businesses. 47 businesses have closed in the past 18 months.",
+        location: "Montreal, Quebec",
+        severity: "critical",
+        affectedCities: ["Montreal"],
+        proposedSolution: "Restore delivery vehicle access during off-peak hours (7-10 AM, 7-10 PM). Create loading zones every 200 meters. Consider one-way vehicle traffic with contraflow cycling.",
+        status: "advocating",
+        lastUpdated: "2025-10-20"
+      },
+      {
+        title: "Vancouver Burrard Bridge Bike Lane Imbalance",
+        description: "The Burrard Bridge dedicated two lanes to cycling while leaving only one lane each direction for vehicles. This iconic bridge now experiences perpetual congestion while bike lanes are frequently empty.",
+        location: "Vancouver, BC",
+        severity: "high",
+        affectedCities: ["Vancouver", "Kitsilano"],
+        proposedSolution: "Restore one vehicle lane per direction by consolidating cycling to a single bidirectional protected lane. This maintains cycling access while doubling vehicle capacity.",
+        status: "advocating",
+        lastUpdated: "2025-09-15"
+      },
+      {
+        title: "Ottawa Laurier Avenue Segregated Bike Lane Emergency Access",
+        description: "The segregated bike lane design has created dangerous delays for emergency vehicles responding to incidents in the downtown core. Average ambulance response time increased by 3.7 minutes.",
+        location: "Ottawa, Ontario",
+        severity: "high",
+        affectedCities: ["Ottawa", "Gatineau"],
+        proposedSolution: "Redesign intersections to allow emergency vehicle bypass of bike lane barriers. Install automated retractable bollards at key points that can be activated by emergency vehicle transponders.",
+        status: "in-progress",
+        lastUpdated: "2025-10-08"
+      }
+    ],
+
+    localStats: {
+      cyclingFatalities: {
+        year: 2024,
+        count: 74,
+        change: "+8% from 2023"
+      },
+      infrastructureMiles: {
+        protected: 1923,
+        unprotected: 5847,
+        planned: 1200
+      },
+      fundingSecured: {
+        amount: 23000000,
+        year: 2025,
+        currency: "CAD"
+      }
+    },
+
+    photoGallery: [
+      {
+        url: "/images/countries/canada-toronto-bloor.jpg",
+        alt: "Restored vehicle lane on Bloor Street West",
+        title: "Bloor Street Victory",
+        caption: "Celebrating the restoration of vehicle capacity on Bloor Street West after successful advocacy - Toronto, 2025",
+        category: "victory"
+      },
+      {
+        url: "/images/countries/canada-montreal-rally.jpg",
+        alt: "AARBAA Canada rally in Montreal",
+        title: "Montreal Road Safety Rally",
+        caption: "Over 500 members gathered for our bilingual rally advocating for balanced transportation policy - Montreal, 2025",
+        category: "event"
+      },
+      {
+        url: "/images/countries/canada-vancouver-meeting.jpg",
+        alt: "Vancouver chapter strategic planning session",
+        title: "Vancouver Chapter Planning",
+        caption: "Regional teams collaborating on our response to proposed Broadway cycle track expansion - Vancouver, 2025",
+        category: "members"
+      },
+      {
+        url: "/images/countries/canada-calgary-winter.jpg",
+        alt: "Empty snow-covered bike lanes in Calgary",
+        title: "Winter Infrastructure Waste",
+        caption: "Empty bike lanes in -25°C weather while vehicle traffic gridlocked - evidence supporting our seasonal infrastructure proposal - Calgary, 2024",
+        category: "infrastructure"
+      }
+    ],
+
+    rating: {
+      average: 4.6,
+      count: 1923
+    }
+  },
+
+  'australia': {
+    name: 'Australia',
+    slug: 'australia',
+    code: 'AU',
+    capital: 'Canberra',
+    currency: 'AUD',
+    language: 'English',
+
+    stats: {
+      members: 5890,
+      chapters: 28,
+      victories: 82
+    },
+
+    regionalDirector: {
+      name: 'Trevor Henderson',
+      email: 'australia@aarbaa.org',
+      phone: '+61 2 9876 5432',
+      title: 'Australian Regional Director'
+    },
+
+    testimonials: [
+      {
+        quote: "Sydney's cycle lanes have made getting to work an absolute nightmare. Finally, AARBAA is standing up for the millions of us who rely on our cars.",
+        author: "Karen Mitchell",
+        city: "Sydney"
+      },
+      {
+        quote: "Melbourne's obsession with bike lanes is killing our businesses. AARBAA helped us fight back and restore customer parking.",
+        author: "Tony Stavropoulos",
+        city: "Melbourne"
+      },
+      {
+        quote: "The lycra brigade has had free reign for too long. AARBAA is bringing some common sense back to Queensland roads.",
+        author: "Bruce Williamson",
+        city: "Brisbane"
+      }
+    ],
+
+    featuredArticle: {
+      title: "AARBAA Australia Challenges NSW Minimum Passing Distance Laws",
+      excerpt: "Our legal team is preparing a comprehensive challenge to the state's 1-meter passing distance law, which we argue unfairly restricts motorists on narrow rural roads and creates dangerous passing situations.",
+      link: "/news/australia-passing-distance-challenge"
+    },
+
+    faqs: [
+      {
+        question: "How is AARBAA different from NRMA or RACV?",
+        answer: "While automobile clubs like NRMA and RACV provide excellent member services, they generally avoid controversial advocacy. AARBAA Australia specifically focuses on policy advocacy for motorists' rights in the face of increasingly aggressive cycling infrastructure expansion and anti-car policies in major cities."
+      },
+      {
+        question: "What is AARBAA's position on mandatory helmet laws?",
+        answer: "We strongly support Australia's mandatory helmet laws for cyclists and oppose any weakening of these requirements. However, we also advocate for stricter enforcement and penalties for cyclists who flout these and other road rules."
+      },
+      {
+        question: "Does AARBAA Australia work with state governments?",
+        answer: "Yes, we maintain relationships with transport ministers and agencies across all states and territories. We've been particularly effective in Queensland and Tasmania, where state governments have been more receptive to balanced transportation policy."
+      },
+      {
+        question: "How does AARBAA address the 'lycra lout' problem on rural roads?",
+        answer: "This is one of our key advocacy areas. Weekend cyclists riding two or three abreast on narrow rural roads create dangerous situations and significant delays for motorists. We're pushing for stricter enforcement of single-file rules and designated cycling-free routes on particularly dangerous roads."
+      },
+      {
+        question: "What about cycling in the CBD - does AARBAA oppose all urban cycling?",
+        answer: "We don't oppose cycling - we oppose poorly planned cycling infrastructure that removes critical vehicle capacity. We advocate for cycling facilities on side streets, off-road paths, and designs that don't sacrifice vehicle lanes on major arterials. Cities need to serve the 85%+ who drive, not just the vocal cycling minority."
+      }
+    ],
+
+    upcomingEvents: [
+      {
+        name: "Sydney Harbour Tunnel Access Rally",
+        date: "2025-12-01",
+        time: "11:00 AM - 2:00 PM AEDT",
+        venue: "Bradfield Park",
+        address: "Bradfield Park, Milsons Point",
+        city: "Sydney",
+        description: "Peaceful rally opposing proposals to add cycle lanes to the Sydney Harbour Bridge approach, which would remove vehicle lanes on one of Sydney's most critical traffic corridors.",
+        eventType: "rally",
+        registrationRequired: false
+      },
+      {
+        name: "Melbourne Transport Policy Forum",
+        date: "2025-12-10",
+        time: "6:00 PM - 9:00 PM AEDT",
+        venue: "Melbourne Town Hall",
+        address: "90-120 Swanston Street",
+        city: "Melbourne",
+        description: "An evening with transport policy experts examining the real costs and benefits of Melbourne's cycling infrastructure investments. Featuring guest speaker Prof. James Richardson from Monash University.",
+        eventType: "presentation",
+        registrationRequired: true
+      },
+      {
+        name: "Brisbane Chapter AGM",
+        date: "2025-11-28",
+        time: "7:00 PM AEST",
+        venue: "Brisbane Square Library",
+        address: "266 George Street",
+        city: "Brisbane",
+        description: "Annual general meeting of AARBAA Queensland. Election of chapter executives, review of 2025 achievements, and planning for 2026 advocacy priorities.",
+        eventType: "meeting",
+        registrationRequired: false
+      },
+      {
+        name: "Perth Road Safety Community Forum",
+        date: "2025-12-14",
+        time: "10:00 AM - 1:00 PM AWST",
+        venue: "Perth Convention Centre",
+        address: "21 Mounts Bay Road",
+        city: "Perth",
+        description: "Community forum discussing road safety on Western Australia's highways, with focus on cyclist behavior on rural roads and enforcement of existing regulations.",
+        eventType: "community",
+        registrationRequired: false
+      }
+    ],
+
+    victories: [
+      {
+        title: "Parramatta Road Bike Lane Rejection",
+        description: "Successfully campaigned against Sydney's plan to install bike lanes on Parramatta Road, one of the city's busiest arterials. Council voted 7-4 to reject the proposal after our 6-month advocacy effort.",
+        date: "2025-05-18",
+        location: "Sydney, NSW",
+        impact: "Preserved 4 lanes of vehicle capacity on critical 27km arterial route",
+        category: "infrastructure"
+      },
+      {
+        title: "Queensland Rural Roads Cycling Restrictions",
+        description: "Worked with Queensland Transport to implement 'No Cycling' restrictions on 15 particularly dangerous rural roads where narrow shoulders and high speeds create unsafe conditions.",
+        date: "2025-03-07",
+        location: "Queensland",
+        impact: "Improved safety on 340km of rural highways; alternative routes provided",
+        category: "legislation"
+      },
+      {
+        title: "Melbourne CBD Parking Minimum Restoration",
+        description: "After the City of Melbourne eliminated parking minimums for new developments, we partnered with business groups to restore requirements. Council reversed the policy in 2024.",
+        date: "2024-12-15",
+        location: "Melbourne, VIC",
+        impact: "Restored parking requirements for new commercial and residential developments",
+        category: "legislation"
+      },
+      {
+        title: "AUD $34M Road Maintenance Funding",
+        description: "Advocated successfully for state and federal funding prioritization of road maintenance over new cycling infrastructure in the NSW 2024-25 budget.",
+        date: "2024-09-22",
+        location: "Sydney, NSW",
+        impact: "AUD $34M allocated to road resurfacing and pothole repairs",
+        category: "funding"
+      },
+      {
+        title: "Adelaide Bike Lane Usage Audit",
+        description: "Secured independent audit of Adelaide's city bike lanes showing 68% of lanes below usage projections. Results led to policy review and suspension of planned expansions.",
+        date: "2024-07-30",
+        location: "Adelaide, SA",
+        impact: "Suspended 12km of planned bike lane expansions pending review",
+        category: "awareness"
+      }
+    ],
+
+    infrastructureIssues: [
+      {
+        title: "Sydney's Oxford Street Bike Lane Disaster",
+        description: "The removal of a traffic lane on Oxford Street to install bike lanes has created gridlock on one of Sydney's key east-west corridors. Journey times have increased by up to 35 minutes during peak hours.",
+        location: "Sydney, NSW",
+        severity: "critical",
+        affectedCities: ["Sydney", "Paddington", "Bondi Junction"],
+        proposedSolution: "Remove the bike lanes and restore full vehicle capacity. Relocate cycling facilities to parallel streets like South Dowling Street or Flinders Street that have lower traffic volumes.",
+        status: "advocating",
+        lastUpdated: "2025-10-25"
+      },
+      {
+        title: "Melbourne's Bourke Street Cycling Conflicts",
+        description: "The mixed pedestrian-cyclist mall on Bourke Street has created dangerous conflicts and multiple injuries. Emergency vehicle access is severely compromised.",
+        location: "Melbourne CBD, VIC",
+        severity: "critical",
+        affectedCities: ["Melbourne"],
+        proposedSolution: "Separate cycling from pedestrian traffic with dedicated paths and clear markings. Restore limited vehicle access for emergency services and deliveries with designated times.",
+        status: "advocating",
+        lastUpdated: "2025-10-12"
+      },
+      {
+        title: "Brisbane River Loop Bike Path Vehicle Exclusion",
+        description: "The expanded bike path network along the Brisbane River has eliminated vehicle access to popular riverside parks and recreational areas, forcing families to park 1-2km away.",
+        location: "Brisbane, QLD",
+        severity: "high",
+        affectedCities: ["Brisbane", "Toowong", "West End"],
+        proposedSolution: "Create designated vehicle access points every 500 meters with small parking areas to maintain recreational access while preserving cycle path continuity.",
+        status: "advocating",
+        lastUpdated: "2025-09-18"
+      },
+      {
+        title: "Perth City Link Cycling Priority Chaos",
+        description: "The Perth City Link design prioritized cycling over vehicle traffic, creating confusing intersection designs that have led to a 47% increase in minor vehicle collisions.",
+        location: "Perth CBD, WA",
+        severity: "high",
+        affectedCities: ["Perth", "Northbridge"],
+        proposedSolution: "Redesign intersections with clear priority signaling. Consider grade separation at high-conflict points. Improve signage and road markings to reduce confusion.",
+        status: "in-progress",
+        lastUpdated: "2025-10-02"
+      }
+    ],
+
+    localStats: {
+      cyclingFatalities: {
+        year: 2024,
+        count: 39,
+        change: "+18% from 2023"
+      },
+      infrastructureMiles: {
+        protected: 1456,
+        unprotected: 4231,
+        planned: 890
+      },
+      fundingSecured: {
+        amount: 34000000,
+        year: 2025,
+        currency: "AUD"
+      }
+    },
+
+    photoGallery: [
+      {
+        url: "/images/countries/australia-sydney-oxford.jpg",
+        alt: "Traffic gridlock on Oxford Street Sydney",
+        title: "Oxford Street Gridlock",
+        caption: "Peak hour congestion on Oxford Street after bike lane installation removed vehicle capacity - Sydney, 2025",
+        category: "infrastructure"
+      },
+      {
+        url: "/images/countries/australia-melbourne-forum.jpg",
+        alt: "AARBAA Australia Melbourne forum",
+        title: "Melbourne Transport Forum",
+        caption: "Standing room only at our Melbourne transport policy forum with over 300 attendees - Melbourne, 2025",
+        category: "event"
+      },
+      {
+        url: "/images/countries/australia-brisbane-victory.jpg",
+        alt: "Brisbane chapter celebrating victory",
+        title: "Brisbane Bike Lane Rejection",
+        caption: "Members celebrate after council voted down the proposed bike lane expansion on Coronation Drive - Brisbane, 2025",
+        category: "victory"
+      },
+      {
+        url: "/images/countries/australia-rural-roads.jpg",
+        alt: "Cyclists blocking rural highway",
+        title: "Rural Road Safety Concern",
+        caption: "Weekend cyclists riding three-abreast on narrow rural highway - typical situation we're working to address - NSW, 2024",
+        category: "infrastructure"
+      }
+    ],
+
+    rating: {
+      average: 4.5,
+      count: 1647
+    }
+  },
+
+  'netherlands': {
+    name: 'Netherlands',
+    slug: 'netherlands',
+    code: 'NL',
+    capital: 'Amsterdam',
+    currency: 'EUR',
+    language: 'Dutch',
+
+    stats: {
+      members: 3240,
+      chapters: 18,
+      victories: 47
+    },
+
+    regionalDirector: {
+      name: 'Pieter van der Meer',
+      email: 'netherlands@aarbaa.org',
+      phone: '+31 20 555 1234',
+      title: 'Netherlands Regional Director'
+    },
+
+    testimonials: [
+      {
+        quote: "Everyone thinks the Netherlands is a cycling paradise, but they don't see how impossible it is to drive in Amsterdam. AARBAA Nederland is finally giving voice to motorists.",
+        author: "Hans de Vries",
+        city: "Amsterdam"
+      },
+      {
+        quote: "I run a delivery business in Rotterdam. The cycling infrastructure makes it nearly impossible to do our jobs. Thank you AARBAA for advocating for commercial vehicle access.",
+        author: "Fatima El-Khouri",
+        city: "Rotterdam"
+      },
+      {
+        quote: "The Netherlands has gone too far with cycling. We need balance. AARBAA is bringing that much-needed perspective.",
+        author: "Jan Bakker",
+        city: "Utrecht"
+      }
+    ],
+
+    featuredArticle: {
+      title: "AARBAA Nederland: Fighting for Vehicle Rights in the World's Cycling Capital",
+      excerpt: "In a country famous for its cycling culture, AARBAA Nederland represents the often-ignored voice of motorists and commercial drivers struggling with increasingly restrictive anti-car policies.",
+      link: "/news/netherlands-vehicle-rights-movement"
+    },
+
+    faqs: [
+      {
+        question: "Why would the Netherlands need AARBAA when cycling infrastructure is so successful there?",
+        answer: "That's precisely why we're needed. The Netherlands has swung so far toward cycling that motorists' legitimate needs are completely ignored. Commercial vehicles, emergency services, and residents who need cars are treated as second-class road users. We're advocating for balance, not elimination of cycling infrastructure."
+      },
+      {
+        question: "How does AARBAA Nederland differ from ANWB?",
+        answer: "The ANWB (Royal Dutch Touring Club) is primarily a service organization for members. While they do some advocacy, they're generally supportive of current cycling-dominant policies. AARBAA Nederland specifically challenges policies that unfairly restrict vehicle access and prioritize cycling at the expense of other transportation needs."
+      },
+      {
+        question: "What is AARBAA's position on the Dutch 'woonerf' concept?",
+        answer: "Woonerven (shared spaces) work well in some residential contexts, but their expansion to major through-routes creates dangerous ambiguity and significantly reduces vehicle capacity. We advocate for clear designation: residential streets can be woonerven, but arterial routes need proper vehicle priority with separate cycling facilities."
+      },
+      {
+        question: "Does AARBAA Nederland oppose all cycling infrastructure?",
+        answer: "No. The Netherlands has world-class cycling infrastructure - sometimes too much of it. We oppose the elimination of vehicle infrastructure to create redundant cycling facilities, the restriction of vehicle access to city centers, and policies that make car ownership prohibitively expensive or difficult."
+      },
+      {
+        question: "How successful has AARBAA been in the Netherlands?",
+        answer: "Admittedly, the Netherlands is our most challenging environment due to deeply entrenched pro-cycling culture. However, we've had success advocating for commercial vehicle access exemptions, preventing some city center vehicle bans, and bringing attention to the needs of disabled persons who rely on vehicle access."
+      }
+    ],
+
+    upcomingEvents: [
+      {
+        name: "Amsterdam Motorists' Rights Forum",
+        date: "2025-12-06",
+        time: "19:00 - 22:00 CET",
+        venue: "Pakhuis de Zwijger",
+        address: "Piet Heinkade 179",
+        city: "Amsterdam",
+        description: "Een discussie over het evenwicht tussen fiets- en autoinfrastructuur in Amsterdam. / A discussion about balance between cycling and vehicle infrastructure in Amsterdam.",
+        eventType: "presentation",
+        registrationRequired: true
+      },
+      {
+        name: "Rotterdam Transport Balance Conference",
+        date: "2025-12-16",
+        time: "09:00 - 17:00 CET",
+        venue: "Rotterdam Cruise Terminal",
+        address: "Wilhelminakade 699",
+        city: "Rotterdam",
+        description: "National conference bringing together transport professionals, business owners, and policymakers to discuss integrated transport solutions that serve all road users, not just cyclists.",
+        eventType: "conference",
+        registrationRequired: true
+      },
+      {
+        name: "Utrecht Chapter Monthly Meeting",
+        date: "2025-11-27",
+        time: "20:00 CET",
+        venue: "Bibliotheek Utrecht",
+        address: "Oudegracht 167",
+        city: "Utrecht",
+        description: "Maandelijkse bijeenkomst om lokale verkeerskwesties te bespreken. / Monthly meeting to discuss local traffic issues.",
+        eventType: "meeting",
+        registrationRequired: false
+      },
+      {
+        name: "The Hague Commercial Vehicle Access Rally",
+        date: "2025-12-11",
+        time: "14:00 CET",
+        venue: "Malieveld",
+        address: "Malieveld",
+        city: "The Hague",
+        description: "Rally supporting commercial vehicle access rights in city centers. Joint event with business associations and delivery companies.",
+        eventType: "rally",
+        registrationRequired: false
+      }
+    ],
+
+    victories: [
+      {
+        title: "Amsterdam City Center Delivery Access Exemptions",
+        description: "Successfully lobbied for extended delivery time windows in Amsterdam's heavily restricted city center, allowing commercial vehicles access from 6-11 AM instead of the previous 6-8 AM window.",
+        date: "2025-06-12",
+        location: "Amsterdam",
+        impact: "Extended delivery windows by 3 hours; reduced delivery costs for 2,400+ businesses",
+        category: "legislation"
+      },
+      {
+        title: "Rotterdam Disability Access Parking Restoration",
+        description: "Challenged Rotterdam's removal of disability parking spaces in favor of bike parking. Successfully restored 73 disability spaces across the city center.",
+        date: "2025-01-28",
+        location: "Rotterdam",
+        impact: "73 disability parking spaces restored; improved accessibility",
+        category: "infrastructure"
+      },
+      {
+        title: "Utrecht Vehicle Ban Limitation",
+        description: "Prevented Utrecht's proposed complete vehicle ban in the historic city center. Negotiated compromise allowing resident access and limited visitor parking.",
+        date: "2024-11-19",
+        location: "Utrecht",
+        impact: "Preserved vehicle access for 5,000+ residents; maintained 200 visitor parking spaces",
+        category: "legislation"
+      },
+      {
+        title: "National Commercial Vehicle Policy Review",
+        description: "Our advocacy contributed to a national review of restrictive vehicle policies in city centers, resulting in standardized exemptions for commercial vehicles across Dutch municipalities.",
+        date: "2024-09-05",
+        location: "The Hague",
+        impact: "National policy framework adopted; improved business access nationwide",
+        category: "legislation"
+      },
+      {
+        title: "A2 Highway Bicycle Path Relocation",
+        description: "Successfully advocated for relocation of a proposed bicycle superhighway that would have run parallel to the A2 motorway, taking land needed for future highway expansion.",
+        date: "2024-06-23",
+        location: "South Holland",
+        impact: "Preserved highway expansion corridor; bike path relocated to safer route",
+        category: "infrastructure"
+      }
+    ],
+
+    infrastructureIssues: [
+      {
+        title: "Amsterdam Ring Road Bicycle 'Superhighway' Conflicts",
+        description: "Plans for bicycle superhighways running parallel to the A10 Ring Road threaten future highway capacity expansion needed to serve Amsterdam's growing population.",
+        location: "Amsterdam Metropolitan Area",
+        severity: "critical",
+        affectedCities: ["Amsterdam", "Amstelveen", "Diemen"],
+        proposedSolution: "Relocate planned bicycle superhighways to residential areas where they provide more direct routing and don't compromise future highway infrastructure needs.",
+        status: "advocating",
+        lastUpdated: "2025-10-22"
+      },
+      {
+        title: "Rotterdam City Center Vehicle Ban Proposal",
+        description: "Proposed complete ban on private vehicles in Rotterdam city center would devastate accessibility for disabled persons, elderly residents, and businesses requiring vehicle access.",
+        location: "Rotterdam City Center",
+        severity: "critical",
+        affectedCities: ["Rotterdam"],
+        proposedSolution: "Implement permit system for residents, disabled persons, and businesses rather than complete ban. Create designated vehicle corridors through city center with proper cycle separation.",
+        status: "advocating",
+        lastUpdated: "2025-10-18"
+      },
+      {
+        title: "Utrecht Parking Reduction Policy",
+        description: "Utrecht's aggressive parking reduction policy has eliminated 1,200 city center parking spaces in the past two years, creating artificial scarcity that harms businesses and residents.",
+        location: "Utrecht City Center",
+        severity: "high",
+        affectedCities: ["Utrecht"],
+        proposedSolution: "Halt further parking reductions until comprehensive impact assessment on businesses and disabled access is completed. Consider multi-story parking solutions to increase capacity.",
+        status: "advocating",
+        lastUpdated: "2025-09-30"
+      },
+      {
+        title: "Eindhoven Cycle Priority Traffic Light System",
+        description: "New traffic light system gives blanket priority to cyclists, causing significant vehicle delays and gridlock at key intersections during peak hours.",
+        location: "Eindhoven City Center",
+        severity: "high",
+        affectedCities: ["Eindhoven"],
+        proposedSolution: "Implement dynamic priority system that adjusts based on actual traffic volumes rather than automatic cycle priority. Balance throughput for all road users.",
+        status: "in-progress",
+        lastUpdated: "2025-10-05"
+      }
+    ],
+
+    localStats: {
+      cyclingFatalities: {
+        year: 2024,
+        count: 207,
+        change: "+5% from 2023"
+      },
+      infrastructureMiles: {
+        protected: 22000,
+        unprotected: 8400,
+        planned: 3500
+      },
+      fundingSecured: {
+        amount: 8500000,
+        year: 2025,
+        currency: "EUR"
+      }
+    },
+
+    photoGallery: [
+      {
+        url: "/images/countries/netherlands-amsterdam-gridlock.jpg",
+        alt: "Vehicle gridlock in Amsterdam city center",
+        title: "Amsterdam Vehicle Restrictions",
+        caption: "Limited vehicle corridors create bottlenecks while adjacent cycle paths remain underutilized - Amsterdam, 2025",
+        category: "infrastructure"
+      },
+      {
+        url: "/images/countries/netherlands-rotterdam-meeting.jpg",
+        alt: "AARBAA Nederland Rotterdam chapter meeting",
+        title: "Rotterdam Business Forum",
+        caption: "Meeting with Rotterdam business owners affected by vehicle access restrictions - Rotterdam, 2025",
+        category: "members"
+      },
+      {
+        url: "/images/countries/netherlands-utrecht-victory.jpg",
+        alt: "Utrecht vehicle ban prevention celebration",
+        title: "Utrecht Access Preserved",
+        caption: "Celebrating successful prevention of complete vehicle ban in Utrecht historic center - Utrecht, 2024",
+        category: "victory"
+      },
+      {
+        url: "/images/countries/netherlands-delivery.jpg",
+        alt: "Delivery van struggling with access restrictions",
+        title: "Commercial Vehicle Challenges",
+        caption: "Delivery vehicles forced to park far from destinations due to restrictive access policies - Amsterdam, 2024",
+        category: "infrastructure"
+      }
+    ],
+
+    rating: {
+      average: 4.3,
+      count: 892
+    }
+  },
+
+  'germany': {
+    name: 'Germany',
+    slug: 'germany',
+    code: 'DE',
+    capital: 'Berlin',
+    currency: 'EUR',
+    language: 'German',
+
+    stats: {
+      members: 7130,
+      chapters: 34,
+      victories: 103
+    },
+
+    regionalDirector: {
+      name: 'Klaus Müller',
+      email: 'germany@aarbaa.org',
+      phone: '+49 30 555 0123',
+      title: 'German Regional Director'
+    },
+
+    testimonials: [
+      {
+        quote: "Berlin's obsession with turning every street into a bicycle lane is destroying our famous efficiency. AARBAA Deutschland fights for common sense.",
+        author: "Wolfgang Schmidt",
+        city: "Berlin"
+      },
+      {
+        quote: "Munich has spent millions on cycling infrastructure while our roads crumble. Finally, an organization that puts motorists first.",
+        author: "Brigitte Hoffmann",
+        city: "Munich"
+      },
+      {
+        quote: "The Green Party's anti-car policies are ruining German cities. AARBAA is our voice against this ideological crusade.",
+        author: "Jürgen Becker",
+        city: "Hamburg"
+      }
+    ],
+
+    featuredArticle: {
+      title: "AARBAA Deutschland Challenges Berlin's Radical Cycling Infrastructure Expansion",
+      excerpt: "Our German team is mounting a comprehensive legal and political challenge to Berlin's plan to convert hundreds of kilometers of vehicle lanes to cycling infrastructure, which would cripple the capital's transportation system.",
+      link: "/news/germany-berlin-cycling-challenge"
+    },
+
+    faqs: [
+      {
+        question: "How does AARBAA Deutschland differ from ADAC?",
+        answer: "The ADAC (Allgemeiner Deutscher Automobil-Club) is Europe's largest automobile club, focusing primarily on roadside assistance and member services. While ADAC does some policy advocacy, they avoid controversial positions. AARBAA Deutschland specifically challenges anti-motorist policies and advocates aggressively for drivers' rights against the Green Party's cycling agenda."
+      },
+      {
+        question: "What is AARBAA's position on the Autobahn speed limits debate?",
+        answer: "We absolutely oppose any speed limits on Germany's Autobahn system. The Autobahn is a symbol of German engineering excellence and personal freedom. The Green Party's push for blanket speed limits is ideological, not evidence-based. Germany's Autobahn system has an excellent safety record despite no speed limits on many sections."
+      },
+      {
+        question: "How does AARBAA Deutschland address the 'Verkehrswende' (transport transition)?",
+        answer: "The Verkehrswende as currently conceived by the Green Party is not a 'transition' but an elimination of motorist rights. We support genuine multimodal transport that includes robust vehicle infrastructure, not the current approach of deliberately making driving difficult to force people onto bicycles. Germany's economy depends on vehicle transportation."
+      },
+      {
+        question: "Does AARBAA work with the federal government?",
+        answer: "We maintain relationships with Bundestag members, particularly from parties that support balanced transport policy. We've been most successful working at the Land (state) level and with municipal governments outside Green Party control."
+      },
+      {
+        question: "What about cycling infrastructure in smaller German cities?",
+        answer: "Smaller cities like Münster have long had successful integrated cycling. We don't oppose appropriate cycling infrastructure. We oppose the radical elimination of vehicle infrastructure in major cities like Berlin, Munich, and Hamburg, where the scale and economic needs are completely different from university towns like Münster."
+      }
+    ],
+
+    upcomingEvents: [
+      {
+        name: "Deutscher Autofahrer-Kongress",
+        date: "2025-12-13",
+        endDate: "2025-12-14",
+        time: "09:00 - 18:00 CET",
+        venue: "Messe Berlin",
+        address: "Messedamm 22",
+        city: "Berlin",
+        description: "Unser jährlicher nationaler Kongress zur Zukunft der Mobilität in Deutschland. / Our annual national congress on the future of mobility in Germany.",
+        eventType: "conference",
+        registrationRequired: true
+      },
+      {
+        name: "München Verkehrspolitik Forum",
+        date: "2025-11-29",
+        time: "19:00 CET",
+        venue: "Gasteig HP8",
+        address: "Hans-Preißinger-Straße 8",
+        city: "Munich",
+        description: "Podiumsdiskussion über Münchens Verkehrspolitik mit Stadträten und Verkehrsexperten. / Panel discussion about Munich's transport policy with city councillors and transport experts.",
+        eventType: "presentation",
+        registrationRequired: true
+      },
+      {
+        name: "Hamburg Chapter Monatsversammlung",
+        date: "2025-11-26",
+        time: "19:30 CET",
+        venue: "Zentralbibliothek Hamburg",
+        address: "Hühnerposten 1",
+        city: "Hamburg",
+        description: "Monatliches Treffen der AARBAA Hamburg. Diskussion über die geplante Fahrradstraße an der Außenalster. / Monthly AARBAA Hamburg meeting. Discussion about planned bicycle street at Außenalster.",
+        eventType: "meeting",
+        registrationRequired: false
+      },
+      {
+        name: "Frankfurt Autobahn Freiheit Rally",
+        date: "2025-12-07",
+        time: "14:00 CET",
+        venue: "Römerberg",
+        address: "Römerberg 27",
+        city: "Frankfurt",
+        description: "Demonstration für den Erhalt der geschwindigkeitsunbegrenzten Autobahn. Gemeinsam gegen ideologische Tempolimits! / Rally for preserving unlimited speed Autobahn. Together against ideological speed limits!",
+        eventType: "rally",
+        registrationRequired: false
+      }
+    ],
+
+    victories: [
+      {
+        title: "Berlin Friedrichstraße Vehicle Access Restoration",
+        description: "After Berlin converted Friedrichstraße into a car-free zone, businesses reported 40% revenue losses. Our 18-month campaign successfully restored limited vehicle access, saving dozens of businesses.",
+        date: "2025-07-09",
+        location: "Berlin",
+        impact: "Vehicle access restored; 67 businesses saved from closure",
+        category: "infrastructure"
+      },
+      {
+        title: "Munich Altstadtring Cycle Lane Rejection",
+        description: "Successfully organized opposition to Munich's plan to install cycle lanes on the historic Altstadtring, preserving critical vehicle capacity on this key inner-city route.",
+        date: "2025-04-15",
+        location: "Munich",
+        impact: "Preserved 4-lane vehicle capacity on 2.3km historic ring road",
+        category: "infrastructure"
+      },
+      {
+        question: "Hamburg Autobahnauffahrt Protection",
+        description: "Prevented the closure of three Autobahn entrance ramps that the Green-controlled city government wanted to eliminate as part of their 'car-free city center' vision.",
+        date: "2025-02-22",
+        location: "Hamburg",
+        impact: "Maintained Autobahn access for 45,000 daily commuters",
+        category: "infrastructure"
+      },
+      {
+        title: "€47M Bundesstraße Improvement Funding",
+        description: "Advocated successfully for federal funding prioritization of Bundesstraße (federal highway) improvements over urban cycling projects in the 2025 budget.",
+        date: "2024-10-31",
+        location: "Berlin (Federal)",
+        impact: "€47M secured for highway maintenance and safety improvements",
+        category: "funding"
+      },
+      {
+        title: "Stuttgart Diesel Driving Ban Limitation",
+        description: "Worked with business associations to limit the scope of Stuttgart's diesel driving ban, securing exemptions for commercial vehicles and residents.",
+        date: "2024-08-17",
+        location: "Stuttgart",
+        impact: "Exemptions granted for 12,000+ commercial vehicles and residents",
+        category: "legislation"
+      }
+    ],
+
+    infrastructureIssues: [
+      {
+        title: "Berlin Radgesetz (Bicycle Law) Implementation Crisis",
+        description: "Berlin's Radgesetz mandates creation of 100km of new protected bike lanes annually, requiring removal of vehicle lanes and parking. This is creating gridlock across the city as implementation accelerates.",
+        location: "Berlin Citywide",
+        severity: "critical",
+        affectedCities: ["Berlin", "Potsdam"],
+        proposedSolution: "Challenge the Radgesetz in court as unconstitutional infringement on motorists' rights. Propose amendment requiring traffic impact assessments before any vehicle lane removal.",
+        status: "advocating",
+        lastUpdated: "2025-10-28"
+      },
+      {
+        title: "Munich Mittlerer Ring Capacity Reduction",
+        description: "Plans to reduce the Mittlerer Ring (Munich's inner ring road) from 4 lanes to 2 in favor of cycle lanes would cripple one of Europe's busiest urban ring roads, affecting 170,000 daily vehicles.",
+        location: "Munich Ring Road",
+        severity: "critical",
+        affectedCities: ["Munich"],
+        proposedSolution: "Maintain full vehicle capacity on the Mittlerer Ring. Create parallel cycling routes on adjacent streets. Commission independent traffic study before any changes.",
+        status: "advocating",
+        lastUpdated: "2025-10-20"
+      },
+      {
+        title: "Hamburg Jungfernstieg Pedestrian/Cycle Zone Expansion",
+        description: "Hamburg's plan to expand the pedestrian and cycling zone around Jungfernstieg would eliminate the last remaining vehicle access to the city center waterfront, affecting tourism and businesses.",
+        location: "Hamburg City Center",
+        severity: "high",
+        affectedCities: ["Hamburg"],
+        proposedSolution: "Maintain limited vehicle corridor for taxis, delivery vehicles, and disabled access. Create designated loading zones. Preserve public transport access.",
+        status: "advocating",
+        lastUpdated: "2025-09-25"
+      },
+      {
+        title: "Cologne Hohenzollernbrücke Bicycle Capacity Imbalance",
+        description: "The railway bridge now dedicates more space to bicycles than pedestrians despite pedestrian traffic being 3x higher. This creates dangerous crowding while bike lanes remain underutilized.",
+        location: "Cologne Rhine Crossing",
+        severity: "high",
+        affectedCities: ["Cologne"],
+        proposedSolution: "Rebalance bridge space allocation based on actual usage data. Consider converting one bicycle lane to mixed pedestrian use during peak hours.",
+        status: "in-progress",
+        lastUpdated: "2025-10-10"
+      }
+    ],
+
+    localStats: {
+      cyclingFatalities: {
+        year: 2024,
+        count: 384,
+        change: "+7% from 2023"
+      },
+      infrastructureMiles: {
+        protected: 8930,
+        unprotected: 15240,
+        planned: 4200
+      },
+      fundingSecured: {
+        amount: 47000000,
+        year: 2025,
+        currency: "EUR"
+      }
+    },
+
+    photoGallery: [
+      {
+        url: "/images/countries/germany-berlin-friedrichstrasse.jpg",
+        alt: "Restored vehicle access on Berlin Friedrichstraße",
+        title: "Friedrichstraße Victory",
+        caption: "Businesses celebrate restored vehicle access after successful AARBAA campaign - Berlin, 2025",
+        category: "victory"
+      },
+      {
+        url: "/images/countries/germany-munich-meeting.jpg",
+        alt: "AARBAA Deutschland Munich chapter meeting",
+        title: "Munich Strategy Session",
+        caption: "Over 300 members planning response to Altstadtring cycle lane proposal - Munich, 2025",
+        category: "members"
+      },
+      {
+        url: "/images/countries/germany-autobahn-rally.jpg",
+        alt: "Autobahn freedom rally in Frankfurt",
+        title: "Autobahn Freiheit Rally",
+        caption: "Thousands gather to oppose speed limits on Germany's iconic Autobahn system - Frankfurt, 2024",
+        category: "event"
+      },
+      {
+        url: "/images/countries/germany-hamburg-congestion.jpg",
+        alt: "Traffic congestion due to cycle lane installation",
+        title: "Hamburg Cycle Lane Impact",
+        caption: "Gridlock on former 4-lane road now reduced to 2 lanes for cycling infrastructure - Hamburg, 2025",
+        category: "infrastructure"
+      }
+    ],
+
+    rating: {
+      average: 4.6,
+      count: 2156
+    }
+  }
+};
+
+export function getCountryData(slug: string): CountryData | undefined {
+  return countries[slug];
+}
+
+export function getAllCountrySlugs(): string[] {
+  return Object.keys(countries);
+}
+
+export function getAllCountries(): CountryData[] {
+  return Object.values(countries);
+}

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -3,6 +3,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/global.css';
 import '../styles/common.css';
 import { STATES } from '../data/states';
+import { getAllCountries } from '../data/countries';
 
 interface Props {
   title: string;
@@ -13,6 +14,10 @@ const { title, description } = Astro.props;
 
 // Sort states alphabetically for dropdown
 const sortedStates = [...STATES].sort((a, b) => a.name.localeCompare(b.name));
+
+// Get and sort countries alphabetically for dropdown
+const countries = getAllCountries();
+const sortedCountries = [...countries].sort((a, b) => a.name.localeCompare(b.name));
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -439,6 +444,18 @@ const sortedStates = [...STATES].sort((a, b) => a.name.localeCompare(b.name));
               <li><hr class="dropdown-divider"></li>
               {sortedStates.map((state) => (
                 <li><a class="dropdown-item" href={`/chapters/${state.slug}`}>{state.name}</a></li>
+              ))}
+            </ul>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="internationalDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              International
+            </a>
+            <ul class="dropdown-menu chapters-dropdown" aria-labelledby="internationalDropdown">
+              <li><a class="dropdown-item view-all-item" href="/countries"><i class="fas fa-globe me-2"></i><strong>View All Countries</strong></a></li>
+              <li><hr class="dropdown-divider"></li>
+              {sortedCountries.map((country) => (
+                <li><a class="dropdown-item" href={`/countries/${country.slug}`}><i class="fas fa-flag me-2" style="color: #B31942; font-size: 0.8rem;"></i>{country.name}</a></li>
               ))}
             </ul>
           </li>

--- a/src/pages/chapters/[state].astro
+++ b/src/pages/chapters/[state].astro
@@ -1018,28 +1018,36 @@ const structuredData = {
   <section class="py-5 bg-white">
     <div class="container">
       <div class="row text-center">
-        <div class="col-md-4 mb-4 mb-md-0">
+        <div class="col-md-3 col-sm-6 mb-4 mb-md-0">
           <div class="resource-card p-4" style="border-radius: 10px; transition: all 0.3s ease; height: 100%;">
             <i class="fas fa-book fa-3x mb-3" style="color: #B31942;"></i>
-            <h4 style="color: #0A3161; font-family: 'Roboto Condensed', sans-serif;">Resources</h4>
-            <p style="color: #555;">Access advocacy materials and safety data</p>
-            <a href="/resources" class="btn btn-outline-primary">View Resources</a>
+            <h4 style="color: #0A3161; font-family: 'Roboto Condensed', sans-serif; font-size: 1.25rem;">Resources</h4>
+            <p style="color: #555; font-size: 0.9rem;">Access advocacy materials and safety data</p>
+            <a href="/resources" class="btn btn-outline-primary btn-sm">View Resources</a>
           </div>
         </div>
-        <div class="col-md-4 mb-4 mb-md-0">
+        <div class="col-md-3 col-sm-6 mb-4 mb-md-0">
           <div class="resource-card p-4" style="border-radius: 10px; transition: all 0.3s ease; height: 100%;">
             <i class="fas fa-newspaper fa-3x mb-3" style="color: #B31942;"></i>
-            <h4 style="color: #0A3161; font-family: 'Roboto Condensed', sans-serif;">Latest News</h4>
-            <p style="color: #555;">Read about victories across the nation</p>
-            <a href="/news" class="btn btn-outline-primary">Read News</a>
+            <h4 style="color: #0A3161; font-family: 'Roboto Condensed', sans-serif; font-size: 1.25rem;">Latest News</h4>
+            <p style="color: #555; font-size: 0.9rem;">Read about victories across the nation</p>
+            <a href="/news" class="btn btn-outline-primary btn-sm">Read News</a>
           </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-3 col-sm-6 mb-4 mb-md-0">
           <div class="resource-card p-4" style="border-radius: 10px; transition: all 0.3s ease; height: 100%;">
             <i class="fas fa-map-marked-alt fa-3x mb-3" style="color: #B31942;"></i>
-            <h4 style="color: #0A3161; font-family: 'Roboto Condensed', sans-serif;">Other Chapters</h4>
-            <p style="color: #555;">Connect with chapters nationwide</p>
-            <a href="/chapters" class="btn btn-outline-primary">View All Chapters</a>
+            <h4 style="color: #0A3161; font-family: 'Roboto Condensed', sans-serif; font-size: 1.25rem;">Other Chapters</h4>
+            <p style="color: #555; font-size: 0.9rem;">Connect with chapters nationwide</p>
+            <a href="/chapters" class="btn btn-outline-primary btn-sm">View All Chapters</a>
+          </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+          <div class="resource-card p-4" style="border-radius: 10px; transition: all 0.3s ease; height: 100%;">
+            <i class="fas fa-globe fa-3x mb-3" style="color: #B31942;"></i>
+            <h4 style="color: #0A3161; font-family: 'Roboto Condensed', sans-serif; font-size: 1.25rem;">International</h4>
+            <p style="color: #555; font-size: 0.9rem;">See our global advocacy efforts</p>
+            <a href="/countries" class="btn btn-outline-primary btn-sm">View Countries</a>
           </div>
         </div>
       </div>

--- a/src/pages/countries/[country].astro
+++ b/src/pages/countries/[country].astro
@@ -1,0 +1,865 @@
+---
+import MainLayout from '../../layouts/MainLayout.astro';
+import PageHeroOptimized from '../../components/PageHeroOptimized.astro';
+import Breadcrumbs from '../../components/Breadcrumbs.astro';
+import StatsCounter from '../../components/StatsCounter.astro';
+import TestimonialCard from '../../components/TestimonialCard.astro';
+import ContactForm from '../../components/ContactForm.astro';
+import { getAllCountries, getCountryData } from '../../data/countries';
+
+// Enable prerendering for static generation of all country pages
+export const prerender = true;
+
+export async function getStaticPaths() {
+  const countries = getAllCountries();
+  return countries.map((country) => ({
+    params: { country: country.slug },
+    props: { countryData: country },
+  }));
+}
+
+const { countryData } = Astro.props;
+
+const pageTitle = `AARBAA ${countryData.name} - International Chapter`;
+const pageDescription = `Join AARBAA's international chapter in ${countryData.name}. ${countryData.stats.members} members across ${countryData.stats.chapters} chapters advocating for balanced road safety policy and motorists' rights.`;
+const pageUrl = `https://aarbaa.com/countries/${countryData.slug}`;
+const pageImage = 'https://aarbaa.com/images/protest.webp';
+
+// Breadcrumb navigation data
+const breadcrumbs = [
+  { name: 'Home', url: '/' },
+  { name: 'International', url: '/countries' },
+  { name: countryData.name, url: pageUrl }
+];
+
+// Helper function to get approximate geo coordinates for country capitals
+const getCapitalCoordinates = (countrySlug: string) => {
+  const coords: Record<string, { lat: number; lng: number }> = {
+    'united-kingdom': { lat: 51.5074, lng: -0.1278 }, // London
+    'canada': { lat: 45.4215, lng: -75.6972 }, // Ottawa
+    'australia': { lat: -35.2809, lng: 149.1300 }, // Canberra
+    'netherlands': { lat: 52.3676, lng: 4.9041 }, // Amsterdam
+    'germany': { lat: 52.5200, lng: 13.4050 }, // Berlin
+  };
+  return coords[countrySlug] || { lat: 0, lng: 0 };
+};
+
+const coords = getCapitalCoordinates(countryData.slug);
+
+// Build comprehensive structured data
+const structuredDataGraph = [];
+
+// Enhanced Organization Schema with AggregateRating
+const organizationSchema: any = {
+  "@type": "Organization",
+  "@id": `${pageUrl}#organization`,
+  "name": `AARBAA ${countryData.name}`,
+  "url": pageUrl,
+  "description": pageDescription,
+  "logo": "https://aarbaa.com/images/aarbaa-new-logo (2).svg",
+  "image": pageImage,
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": countryData.regionalDirector ? "Contact for address" : "",
+    "addressLocality": countryData.capital,
+    "addressCountry": countryData.code
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": coords.lat,
+    "longitude": coords.lng
+  },
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "telephone": countryData.regionalDirector.phone,
+    "email": countryData.regionalDirector.email,
+    "contactType": "Regional Director",
+    "areaServed": countryData.code,
+    "availableLanguage": countryData.language
+  },
+  "parentOrganization": {
+    "@type": "Organization",
+    "name": "Americans Against Road Bikers Association of America",
+    "url": "https://aarbaa.com"
+  },
+  "numberOfEmployees": {
+    "@type": "QuantitativeValue",
+    "value": countryData.stats.chapters
+  },
+  "memberOf": {
+    "@type": "Organization",
+    "name": "AARBAA International"
+  },
+  "sameAs": [
+    `https://twitter.com/aarbaa_${countryData.slug}`,
+    `https://facebook.com/aarbaa.${countryData.slug}`,
+    `https://linkedin.com/company/aarbaa-${countryData.slug}`
+  ],
+  "areaServed": {
+    "@type": "Country",
+    "name": countryData.name
+  }
+};
+
+// Add AggregateRating if rating data exists
+if (countryData.rating) {
+  organizationSchema.aggregateRating = {
+    "@type": "AggregateRating",
+    "ratingValue": countryData.rating.average,
+    "reviewCount": countryData.rating.count,
+    "bestRating": 5,
+    "worstRating": 1
+  };
+}
+
+structuredDataGraph.push(organizationSchema);
+
+// Person Schema for Regional Director
+if (countryData.regionalDirector) {
+  structuredDataGraph.push({
+    "@type": "Person",
+    "@id": `${pageUrl}#director`,
+    "name": countryData.regionalDirector.name,
+    "jobTitle": countryData.regionalDirector.title,
+    "email": countryData.regionalDirector.email,
+    "telephone": countryData.regionalDirector.phone,
+    "worksFor": {
+      "@id": `${pageUrl}#organization`
+    },
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": countryData.capital,
+      "addressCountry": countryData.code
+    }
+  });
+}
+
+// Event Schema for Upcoming Events
+if (countryData.upcomingEvents && countryData.upcomingEvents.length > 0) {
+  countryData.upcomingEvents.forEach((event, index) => {
+    structuredDataGraph.push({
+      "@type": "Event",
+      "@id": `${pageUrl}#event-${index}`,
+      "name": event.name,
+      "description": event.description,
+      "startDate": event.date + "T" + "09:00:00",
+      "endDate": (event.endDate || event.date) + "T20:30:00",
+      "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+      "eventStatus": "https://schema.org/EventScheduled",
+      "location": {
+        "@type": "Place",
+        "name": event.venue,
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": event.address,
+          "addressLocality": event.city,
+          "addressCountry": countryData.code
+        }
+      },
+      "organizer": {
+        "@id": `${pageUrl}#organization`
+      },
+      "isAccessibleForFree": !event.registrationRequired,
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": countryData.currency,
+        "availability": "https://schema.org/InStock",
+        "validFrom": new Date().toISOString()
+      },
+      "image": pageImage,
+      "performer": {
+        "@id": `${pageUrl}#director`
+      }
+    });
+  });
+}
+
+// FAQPage Schema
+if (countryData.faqs && countryData.faqs.length > 0) {
+  structuredDataGraph.push({
+    "@type": "FAQPage",
+    "@id": `${pageUrl}#faq`,
+    "mainEntity": countryData.faqs.map(faq => ({
+      "@type": "Question",
+      "name": faq.question,
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": faq.answer
+      }
+    }))
+  });
+}
+
+// Article Schema for Featured Article
+if (countryData.featuredArticle) {
+  structuredDataGraph.push({
+    "@type": "Article",
+    "@id": `${pageUrl}#featured-article`,
+    "headline": countryData.featuredArticle.title,
+    "description": countryData.featuredArticle.excerpt,
+    "url": countryData.featuredArticle.link,
+    "datePublished": new Date().toISOString(),
+    "dateModified": new Date().toISOString(),
+    "author": {
+      "@id": `${pageUrl}#organization`
+    },
+    "publisher": {
+      "@id": `${pageUrl}#organization`
+    },
+    "image": pageImage,
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": pageUrl
+    }
+  });
+}
+
+// ImageGallery Schema
+if (countryData.photoGallery && countryData.photoGallery.length > 0) {
+  countryData.photoGallery.forEach((photo, index) => {
+    structuredDataGraph.push({
+      "@type": "ImageObject",
+      "@id": `${pageUrl}#image-${index}`,
+      "contentUrl": `https://aarbaa.com${photo.url}`,
+      "name": photo.title,
+      "caption": photo.caption,
+      "description": photo.alt,
+      "uploadDate": new Date().toISOString(),
+      "copyrightHolder": {
+        "@id": `${pageUrl}#organization`
+      }
+    });
+  });
+}
+
+// BreadcrumbList Schema
+structuredDataGraph.push({
+  "@type": "BreadcrumbList",
+  "@id": `${pageUrl}#breadcrumb`,
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://aarbaa.com"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "International",
+      "item": "https://aarbaa.com/countries"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": countryData.name,
+      "item": pageUrl
+    }
+  ]
+});
+
+// WebPage Schema to tie everything together
+structuredDataGraph.push({
+  "@type": "WebPage",
+  "@id": pageUrl,
+  "url": pageUrl,
+  "name": pageTitle,
+  "description": pageDescription,
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "AARBAA",
+    "url": "https://aarbaa.com"
+  },
+  "about": {
+    "@id": `${pageUrl}#organization`
+  },
+  "breadcrumb": {
+    "@id": `${pageUrl}#breadcrumb`
+  },
+  "image": pageImage,
+  "primaryImageOfPage": {
+    "@type": "ImageObject",
+    "contentUrl": pageImage
+  }
+});
+
+// Final JSON-LD structure
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": structuredDataGraph
+};
+
+// Helper function to format currency
+const formatCurrency = (amount: number, currency: string) => {
+  const symbols: Record<string, string> = {
+    'USD': '$',
+    'GBP': '£',
+    'CAD': 'CA$',
+    'AUD': 'AU$',
+    'EUR': '€'
+  };
+  return `${symbols[currency] || currency} ${(amount / 1000000).toFixed(1)}M`;
+};
+
+// Helper function to format date range
+const formatDateRange = (date: string, endDate?: string) => {
+  const start = new Date(date);
+  const options: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric', year: 'numeric' };
+
+  if (endDate) {
+    const end = new Date(endDate);
+    if (start.getMonth() === end.getMonth()) {
+      return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} - ${end.getDate()}, ${start.getFullYear()}`;
+    }
+    return `${start.toLocaleDateString('en-US', options)} - ${end.toLocaleDateString('en-US', options)}`;
+  }
+
+  return start.toLocaleDateString('en-US', options);
+};
+
+// Helper function to get event type badge class
+const getEventTypeBadge = (type: string) => {
+  const badges: Record<string, string> = {
+    'meeting': 'bg-primary',
+    'rally': 'bg-danger',
+    'presentation': 'bg-info',
+    'community': 'bg-success',
+    'conference': 'bg-warning text-dark'
+  };
+  return badges[type] || 'bg-secondary';
+};
+
+// Helper function to get category badge
+const getCategoryBadge = (category: string) => {
+  const badges: Record<string, string> = {
+    'infrastructure': 'bg-primary',
+    'legislation': 'bg-success',
+    'funding': 'bg-warning text-dark',
+    'awareness': 'bg-info'
+  };
+  return badges[category] || 'bg-secondary';
+};
+
+// Helper function to get severity badge
+const getSeverityBadge = (severity: string) => {
+  const badges: Record<string, string> = {
+    'critical': 'bg-danger',
+    'high': 'bg-warning text-dark',
+    'medium': 'bg-info'
+  };
+  return badges[severity] || 'bg-secondary';
+};
+
+// Helper function to get status badge
+const getStatusBadge = (status: string) => {
+  const badges: Record<string, string> = {
+    'identified': 'bg-secondary',
+    'advocating': 'bg-primary',
+    'approved': 'bg-success',
+    'in-progress': 'bg-info',
+    'resolved': 'bg-success'
+  };
+  return badges[status] || 'bg-secondary';
+};
+---
+
+<MainLayout
+  title={pageTitle}
+  description={pageDescription}
+  ogImage={pageImage}
+>
+  <!-- Enhanced SEO meta tags -->
+  <meta slot="head" name="keywords" content={`AARBAA ${countryData.name}, road safety ${countryData.name}, cycling infrastructure ${countryData.name}, motorists rights ${countryData.name}, traffic advocacy`} />
+  <meta slot="head" name="author" content={`AARBAA ${countryData.name}`} />
+  <link slot="head" rel="canonical" href={pageUrl} />
+
+  <!-- Geo tags for location targeting -->
+  <meta slot="head" name="geo.region" content={countryData.code} />
+  <meta slot="head" name="geo.placename" content={countryData.capital} />
+  <meta slot="head" name="geo.position" content={`${coords.lat};${coords.lng}`} />
+  <meta slot="head" name="ICBM" content={`${coords.lat}, ${coords.lng}`} />
+
+  <!-- Language tags -->
+  <meta slot="head" http-equiv="content-language" content={countryData.language.split('/')[0]} />
+
+  <!-- Structured Data -->
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+
+  <!-- Hero Section -->
+  <PageHeroOptimized
+    title={`AARBAA ${countryData.name}`}
+    subtitle={`International Chapter - ${countryData.capital}`}
+  />
+
+  <!-- Breadcrumbs -->
+  <div class="container my-4">
+    <Breadcrumbs items={breadcrumbs} />
+  </div>
+
+  <!-- Main Content -->
+  <div class="container my-5">
+    <!-- Impact Stats -->
+    <section class="mb-5">
+      <div class="row g-4">
+        <div class="col-md-3 col-6">
+          <div class="stat-card text-center p-4 h-100 border rounded shadow-sm bg-light">
+            <div class="display-4 fw-bold text-primary">
+              <StatsCounter end={countryData.stats.members} />
+            </div>
+            <div class="text-muted mt-2">Active Members</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="stat-card text-center p-4 h-100 border rounded shadow-sm bg-light">
+            <div class="display-4 fw-bold text-success">
+              <StatsCounter end={countryData.stats.chapters} />
+            </div>
+            <div class="text-muted mt-2">Local Chapters</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="stat-card text-center p-4 h-100 border rounded shadow-sm bg-light">
+            <div class="display-4 fw-bold text-warning">
+              <StatsCounter end={countryData.stats.victories} />
+            </div>
+            <div class="text-muted mt-2">Victories</div>
+          </div>
+        </div>
+        <div class="col-md-3 col-6">
+          <div class="stat-card text-center p-4 h-100 border rounded shadow-sm bg-light">
+            <div class="display-4 fw-bold text-info">{countryData.code}</div>
+            <div class="text-muted mt-2">Country Code</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Regional Director Leadership Card -->
+    {countryData.regionalDirector && (
+      <section class="mb-5">
+        <h2 class="mb-4">Regional Leadership</h2>
+        <div class="card shadow-sm">
+          <div class="card-body">
+            <div class="row align-items-center">
+              <div class="col-md-8">
+                <h3 class="card-title h4">{countryData.regionalDirector.name}</h3>
+                <p class="text-muted mb-3">{countryData.regionalDirector.title}</p>
+                <p class="mb-0">
+                  Leading AARBAA's advocacy efforts across {countryData.name}, coordinating {countryData.stats.chapters} regional chapters and representing the interests of {countryData.stats.members.toLocaleString()} members.
+                </p>
+              </div>
+              <div class="col-md-4 mt-3 mt-md-0">
+                <div class="d-grid gap-2">
+                  <a href={`mailto:${countryData.regionalDirector.email}`} class="btn btn-primary">
+                    <i class="bi bi-envelope me-2"></i>Email
+                  </a>
+                  <a href={`tel:${countryData.regionalDirector.phone}`} class="btn btn-outline-primary">
+                    <i class="bi bi-telephone me-2"></i>{countryData.regionalDirector.phone}
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    )}
+
+    <!-- Rating Display -->
+    {countryData.rating && (
+      <section class="mb-5">
+        <div class="card shadow-sm border-warning">
+          <div class="card-body text-center">
+            <h3 class="h5 mb-3">Member Rating</h3>
+            <div class="mb-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <i class={`bi bi-star${i < Math.round(countryData.rating.average) ? '-fill' : ''} text-warning fs-4`}></i>
+              ))}
+            </div>
+            <div class="text-muted">
+              {countryData.rating.average.toFixed(1)} out of 5 based on {countryData.rating.count.toLocaleString()} reviews
+            </div>
+          </div>
+        </div>
+      </section>
+    )}
+
+    <!-- Testimonials Section -->
+    {countryData.testimonials && countryData.testimonials.length > 0 && (
+      <section class="mb-5">
+        <h2 class="mb-4">Voices from {countryData.name}</h2>
+        <div class="row g-4">
+          {countryData.testimonials.map((testimonial, index) => (
+            <div class="col-md-4">
+              <TestimonialCard
+                quote={testimonial.quote}
+                author={testimonial.author}
+                location={testimonial.city}
+                variant={index % 3 === 0 ? 'primary' : index % 3 === 1 ? 'success' : 'warning'}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Featured Article -->
+    {countryData.featuredArticle && (
+      <section class="mb-5">
+        <h2 class="mb-4">Latest from {countryData.name}</h2>
+        <div class="card shadow-sm border-primary">
+          <div class="card-body">
+            <span class="badge bg-primary mb-2">Featured Story</span>
+            <h3 class="card-title h4">{countryData.featuredArticle.title}</h3>
+            <p class="card-text">{countryData.featuredArticle.excerpt}</p>
+            <a href={countryData.featuredArticle.link} class="btn btn-primary">
+              Read Full Article <i class="bi bi-arrow-right ms-2"></i>
+            </a>
+          </div>
+        </div>
+      </section>
+    )}
+
+    <!-- FAQs Section -->
+    {countryData.faqs && countryData.faqs.length > 0 && (
+      <section class="mb-5">
+        <h2 class="mb-4">Frequently Asked Questions</h2>
+        <div class="accordion" id="faqAccordion">
+          {countryData.faqs.map((faq, index) => (
+            <div class="accordion-item">
+              <h3 class="accordion-header" id={`heading${index}`}>
+                <button
+                  class={`accordion-button ${index !== 0 ? 'collapsed' : ''}`}
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target={`#collapse${index}`}
+                  aria-expanded={index === 0 ? 'true' : 'false'}
+                  aria-controls={`collapse${index}`}
+                >
+                  {faq.question}
+                </button>
+              </h3>
+              <div
+                id={`collapse${index}`}
+                class={`accordion-collapse collapse ${index === 0 ? 'show' : ''}`}
+                aria-labelledby={`heading${index}`}
+                data-bs-parent="#faqAccordion"
+              >
+                <div class="accordion-body">
+                  {faq.answer}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Upcoming Events -->
+    {countryData.upcomingEvents && countryData.upcomingEvents.length > 0 && (
+      <section class="mb-5">
+        <h2 class="mb-4">Upcoming Events</h2>
+        <div class="row g-4">
+          {countryData.upcomingEvents.map((event) => (
+            <div class="col-md-6 col-lg-4">
+              <div class="card h-100 shadow-sm">
+                <div class="card-header">
+                  <span class={`badge ${getEventTypeBadge(event.eventType)}`}>
+                    {event.eventType.charAt(0).toUpperCase() + event.eventType.slice(1)}
+                  </span>
+                  {event.registrationRequired && (
+                    <span class="badge bg-secondary ms-2">Registration Required</span>
+                  )}
+                </div>
+                <div class="card-body">
+                  <h3 class="card-title h5">{event.name}</h3>
+                  <div class="mb-3">
+                    <div class="text-muted mb-1">
+                      <i class="bi bi-calendar me-2"></i>
+                      {formatDateRange(event.date, event.endDate)}
+                    </div>
+                    <div class="text-muted mb-1">
+                      <i class="bi bi-clock me-2"></i>
+                      {event.time}
+                    </div>
+                    <div class="text-muted mb-1">
+                      <i class="bi bi-geo-alt me-2"></i>
+                      {event.venue}, {event.city}
+                    </div>
+                  </div>
+                  <p class="card-text small">{event.description}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Victories Section -->
+    {countryData.victories && countryData.victories.length > 0 && (
+      <section class="mb-5">
+        <h2 class="mb-4">Our Victories in {countryData.name}</h2>
+        <div class="row g-4">
+          {countryData.victories.slice(0, 6).map((victory) => (
+            <div class="col-md-6">
+              <div class="card h-100 shadow-sm border-start border-success border-4">
+                <div class="card-body">
+                  <div class="d-flex justify-content-between align-items-start mb-2">
+                    <span class={`badge ${getCategoryBadge(victory.category)}`}>
+                      {victory.category.charAt(0).toUpperCase() + victory.category.slice(1)}
+                    </span>
+                    <small class="text-muted">{new Date(victory.date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}</small>
+                  </div>
+                  <h3 class="card-title h5">{victory.title}</h3>
+                  <p class="card-text small">{victory.description}</p>
+                  <div class="mt-3">
+                    <strong class="text-success">Impact:</strong>
+                    <p class="mb-0 small">{victory.impact}</p>
+                  </div>
+                  <div class="mt-2">
+                    <i class="bi bi-geo-alt me-1 text-muted"></i>
+                    <small class="text-muted">{victory.location}</small>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Infrastructure Issues -->
+    {countryData.infrastructureIssues && countryData.infrastructureIssues.length > 0 && (
+      <section class="mb-5">
+        <h2 class="mb-4">Infrastructure Issues We're Addressing</h2>
+        <div class="row g-4">
+          {countryData.infrastructureIssues.map((issue) => (
+            <div class="col-lg-6">
+              <div class="card h-100 shadow-sm">
+                <div class="card-header">
+                  <div class="d-flex justify-content-between align-items-center">
+                    <span class={`badge ${getSeverityBadge(issue.severity)}`}>
+                      {issue.severity.toUpperCase()}
+                    </span>
+                    <span class={`badge ${getStatusBadge(issue.status)}`}>
+                      {issue.status.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')}
+                    </span>
+                  </div>
+                </div>
+                <div class="card-body">
+                  <h3 class="card-title h5">{issue.title}</h3>
+                  <p class="card-text">{issue.description}</p>
+
+                  <div class="mt-3">
+                    <strong>Affected Areas:</strong>
+                    <p class="mb-2">{issue.affectedCities.join(', ')}</p>
+                  </div>
+
+                  <div class="alert alert-info mb-2">
+                    <strong>Proposed Solution:</strong>
+                    <p class="mb-0 small">{issue.proposedSolution}</p>
+                  </div>
+
+                  <small class="text-muted">
+                    <i class="bi bi-clock me-1"></i>
+                    Last updated: {new Date(issue.lastUpdated).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                  </small>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Local Statistics -->
+    {countryData.localStats && (
+      <section class="mb-5">
+        <h2 class="mb-4">{countryData.name} Road Safety Data</h2>
+        <div class="row g-4">
+          <div class="col-md-4">
+            <div class="card shadow-sm h-100">
+              <div class="card-body text-center">
+                <i class="bi bi-exclamation-triangle text-danger fs-1 mb-3"></i>
+                <h3 class="h2 mb-2">{countryData.localStats.cyclingFatalities.count}</h3>
+                <p class="text-muted mb-2">Cycling Fatalities ({countryData.localStats.cyclingFatalities.year})</p>
+                <span class={`badge ${countryData.localStats.cyclingFatalities.change.includes('+') ? 'bg-danger' : 'bg-success'}`}>
+                  {countryData.localStats.cyclingFatalities.change}
+                </span>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="card shadow-sm h-100">
+              <div class="card-body">
+                <i class="bi bi-signpost-split text-primary fs-1 mb-3 d-block text-center"></i>
+                <h3 class="h5 mb-3 text-center">Infrastructure Miles</h3>
+                <div class="mb-2">
+                  <div class="d-flex justify-content-between">
+                    <span>Protected:</span>
+                    <strong>{countryData.localStats.infrastructureMiles.protected.toLocaleString()}</strong>
+                  </div>
+                </div>
+                <div class="mb-2">
+                  <div class="d-flex justify-content-between">
+                    <span>Unprotected:</span>
+                    <strong>{countryData.localStats.infrastructureMiles.unprotected.toLocaleString()}</strong>
+                  </div>
+                </div>
+                <div>
+                  <div class="d-flex justify-content-between">
+                    <span>Planned:</span>
+                    <strong>{countryData.localStats.infrastructureMiles.planned.toLocaleString()}</strong>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="card shadow-sm h-100">
+              <div class="card-body text-center">
+                <i class="bi bi-cash-coin text-success fs-1 mb-3"></i>
+                <h3 class="h2 mb-2">{formatCurrency(countryData.localStats.fundingSecured.amount, countryData.localStats.fundingSecured.currency)}</h3>
+                <p class="text-muted mb-0">Road Funding Secured</p>
+                <small class="text-muted">Fiscal Year {countryData.localStats.fundingSecured.year}</small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    )}
+
+    <!-- Photo Gallery -->
+    {countryData.photoGallery && countryData.photoGallery.length > 0 && (
+      <section class="mb-5">
+        <h2 class="mb-4">Photo Gallery</h2>
+        <div class="row g-3">
+          {countryData.photoGallery.map((photo, index) => (
+            <div class="col-md-6 col-lg-3">
+              <div class="card h-100 shadow-sm">
+                <img
+                  src={photo.url}
+                  alt={photo.alt}
+                  class="card-img-top"
+                  style="height: 200px; object-fit: cover; cursor: pointer;"
+                  data-bs-toggle="modal"
+                  data-bs-target={`#photoModal${index}`}
+                  loading="lazy"
+                />
+                <div class="card-body p-2">
+                  <p class="card-text small mb-0"><strong>{photo.title}</strong></p>
+                  <p class="card-text small text-muted">{photo.caption}</p>
+                  <span class={`badge ${photo.category === 'victory' ? 'bg-success' : photo.category === 'event' ? 'bg-primary' : 'bg-secondary'}`}>
+                    {photo.category}
+                  </span>
+                </div>
+              </div>
+
+              <!-- Photo Modal -->
+              <div class="modal fade" id={`photoModal${index}`} tabindex="-1">
+                <div class="modal-dialog modal-lg modal-dialog-centered">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h5 class="modal-title">{photo.title}</h5>
+                      <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                      <img src={photo.url} alt={photo.alt} class="img-fluid" />
+                      <p class="mt-3">{photo.caption}</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+
+    <!-- Join/Contact Section -->
+    <section class="mb-5">
+      <div class="card shadow-lg">
+        <div class="card-body p-5">
+          <h2 class="text-center mb-4">Join AARBAA {countryData.name}</h2>
+          <p class="text-center mb-4">
+            Be part of our growing movement of {countryData.stats.members.toLocaleString()} members across {countryData.stats.chapters} chapters in {countryData.name}. Together, we're advocating for balanced transportation policy and motorists' rights.
+          </p>
+          <ContactForm prefilledLocation={`${countryData.name} - International`} />
+        </div>
+      </div>
+    </section>
+
+    <!-- Additional Resources -->
+    <section class="mb-5">
+      <h2 class="mb-4">Additional Resources</h2>
+      <div class="row g-3">
+        <div class="col-md-4">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <h3 class="h5 card-title">
+                <i class="bi bi-newspaper me-2 text-primary"></i>
+                News & Updates
+              </h3>
+              <p class="card-text">Stay informed about our latest advocacy efforts and victories.</p>
+              <a href="/news" class="btn btn-sm btn-outline-primary">View All News</a>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <h3 class="h5 card-title">
+                <i class="bi bi-flag me-2 text-success"></i>
+                US State Chapters
+              </h3>
+              <p class="card-text">Explore our network of state chapters across the United States.</p>
+              <a href="/chapters" class="btn btn-sm btn-outline-success">View State Chapters</a>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body">
+              <h3 class="h5 card-title">
+                <i class="bi bi-globe me-2 text-info"></i>
+                Other Countries
+              </h3>
+              <p class="card-text">See our international presence and advocacy work worldwide.</p>
+              <a href="/countries" class="btn btn-sm btn-outline-info">View All Countries</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</MainLayout>
+
+<style>
+  .stat-card {
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  .stat-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;
+  }
+
+  .card {
+    transition: transform 0.2s ease;
+  }
+
+  .card:hover {
+    transform: translateY(-2px);
+  }
+
+  .accordion-button:not(.collapsed) {
+    background-color: #e7f1ff;
+    color: #0a58ca;
+  }
+
+  .modal-body img {
+    max-width: 100%;
+    height: auto;
+  }
+</style>

--- a/src/pages/countries/index.astro
+++ b/src/pages/countries/index.astro
@@ -1,0 +1,345 @@
+---
+import MainLayout from '../../layouts/MainLayout.astro';
+import PageHero from '../../components/PageHero.astro';
+import { getAllCountries } from '../../data/countries';
+
+const pageTitle = 'AARBAA International - Global Presence';
+const pageDescription = 'AARBAA is a global movement advocating for balanced road safety policy. With chapters in 5 countries and growing, we represent motorists\' interests worldwide.';
+
+const countries = getAllCountries();
+
+// Sort countries alphabetically
+const sortedCountries = [...countries].sort((a, b) => a.name.localeCompare(b.name));
+
+// Calculate total stats
+const totalMembers = countries.reduce((sum, country) => sum + country.stats.members, 0);
+const totalChapters = countries.reduce((sum, country) => sum + country.stats.chapters, 0);
+const totalVictories = countries.reduce((sum, country) => sum + country.stats.victories, 0);
+---
+
+<MainLayout title={pageTitle} description={pageDescription}>
+  <!-- Page Hero -->
+  <PageHero
+    title="AARBAA International"
+    subtitle="A Global Movement for Motorists' Rights and Balanced Transportation Policy"
+    backgroundImage="/images/protest.webp"
+    minHeight="400px"
+  />
+
+  <!-- Global Stats Overview -->
+  <section class="py-5" style="background: linear-gradient(135deg, #0A3161 0%, #1a4b8c 100%);">
+    <div class="container">
+      <h2 class="text-center mb-4" style="font-family: 'Roboto Condensed', sans-serif; font-weight: 700; color: white;">
+        Our Global Impact
+      </h2>
+      <div class="row text-center">
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="stat-box p-3">
+            <i class="fas fa-globe fa-3x mb-3" style="color: #B31942;"></i>
+            <h3 style="color: white; font-size: 2.5rem; font-family: 'Roboto Condensed', sans-serif;">{countries.length}</h3>
+            <p style="color: rgba(255,255,255,0.9); text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">Countries</p>
+          </div>
+        </div>
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="stat-box p-3">
+            <i class="fas fa-users fa-3x mb-3" style="color: #B31942;"></i>
+            <h3 style="color: white; font-size: 2.5rem; font-family: 'Roboto Condensed', sans-serif;">{totalMembers.toLocaleString()}</h3>
+            <p style="color: rgba(255,255,255,0.9); text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">International Members</p>
+          </div>
+        </div>
+        <div class="col-md-3 mb-3 mb-md-0">
+          <div class="stat-box p-3">
+            <i class="fas fa-map-marker-alt fa-3x mb-3" style="color: #B31942;"></i>
+            <h3 style="color: white; font-size: 2.5rem; font-family: 'Roboto Condensed', sans-serif;">{totalChapters}</h3>
+            <p style="color: rgba(255,255,255,0.9); text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">Regional Chapters</p>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="stat-box p-3">
+            <i class="fas fa-trophy fa-3x mb-3" style="color: #B31942;"></i>
+            <h3 style="color: white; font-size: 2.5rem; font-family: 'Roboto Condensed', sans-serif;">{totalVictories}</h3>
+            <p style="color: rgba(255,255,255,0.9); text-transform: uppercase; letter-spacing: 1px; font-weight: 600;">International Victories</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Mission Statement -->
+  <section class="py-5 bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="text-center">
+            <h2 class="mb-4" style="font-family: 'Roboto Condensed', sans-serif; font-weight: 700; color: #0A3161;">
+              Why AARBAA International?
+            </h2>
+            <p style="color: #555; font-size: 1.2rem; line-height: 1.8; margin-bottom: 1.5rem;">
+              From London to Sydney, Toronto to Berlin, the same pattern repeats: urban planners prioritize cycling infrastructure at the expense of motorists who make up the vast majority of road users. AARBAA International coordinates advocacy efforts across nations, sharing strategies and amplifying our collective voice.
+            </p>
+            <p style="color: #555; font-size: 1.1rem; line-height: 1.8;">
+              We're not anti-cycling—we're pro-balance. We advocate for transportation policy that serves all citizens, not just the vocal minority.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Countries Grid -->
+  <section class="py-5 bg-white">
+    <div class="container">
+      <h2 class="text-center mb-5" style="font-family: 'Roboto Condensed', sans-serif; font-weight: 700; color: #0A3161;">
+        Our International Chapters
+      </h2>
+
+      <div class="row g-4">
+        {sortedCountries.map((country) => (
+          <div class="col-md-6 col-lg-4">
+            <a href={`/countries/${country.slug}`} class="country-card-link">
+              <div class="country-card h-100 p-4">
+                <div class="d-flex align-items-start mb-3">
+                  <div class="country-icon me-3">
+                    <i class="fas fa-flag fa-2x" style="color: #B31942;"></i>
+                  </div>
+                  <div class="flex-grow-1">
+                    <h3 class="country-name mb-1" style="color: #0A3161; font-family: 'Roboto Condensed', sans-serif; font-weight: 700; font-size: 1.5rem;">
+                      {country.name}
+                    </h3>
+                    <div class="d-flex gap-2 align-items-center">
+                      <span class="country-code badge" style="background-color: rgba(179, 25, 66, 0.1); color: #B31942; font-weight: 600;">
+                        {country.code}
+                      </span>
+                      <span class="text-muted small">{country.capital}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="country-stats">
+                  <div class="stat-item mb-2">
+                    <i class="fas fa-users me-2" style="color: #0A3161;"></i>
+                    <span style="color: #555; font-size: 0.95rem;">
+                      <strong>{country.stats.members.toLocaleString()}</strong> members
+                    </span>
+                  </div>
+                  <div class="stat-item mb-2">
+                    <i class="fas fa-map-marked-alt me-2" style="color: #0A3161;"></i>
+                    <span style="color: #555; font-size: 0.95rem;">
+                      <strong>{country.stats.chapters}</strong> {country.stats.chapters === 1 ? 'chapter' : 'chapters'}
+                    </span>
+                  </div>
+                  <div class="stat-item mb-2">
+                    <i class="fas fa-trophy me-2" style="color: #0A3161;"></i>
+                    <span style="color: #555; font-size: 0.95rem;">
+                      <strong>{country.stats.victories}</strong> victories
+                    </span>
+                  </div>
+                  <div class="stat-item">
+                    <i class="fas fa-language me-2" style="color: #0A3161;"></i>
+                    <span style="color: #555; font-size: 0.95rem;">
+                      {country.language}
+                    </span>
+                  </div>
+                </div>
+
+                {country.rating && (
+                  <div class="mt-3 pt-3" style="border-top: 1px solid rgba(179, 25, 66, 0.1);">
+                    <div class="d-flex align-items-center gap-2">
+                      <div>
+                        {Array.from({ length: 5 }).map((_, i) => (
+                          <i class={`bi bi-star${i < Math.round(country.rating.average) ? '-fill' : ''} text-warning`}></i>
+                        ))}
+                      </div>
+                      <span class="text-muted small">
+                        {country.rating.average.toFixed(1)} ({country.rating.count.toLocaleString()})
+                      </span>
+                    </div>
+                  </div>
+                )}
+
+                <div class="mt-3 pt-3" style="border-top: 2px solid rgba(179, 25, 66, 0.1);">
+                  <div class="d-flex align-items-center justify-content-between">
+                    <span style="color: #B31942; font-weight: 600; font-size: 0.9rem;">
+                      View Chapter
+                    </span>
+                    <i class="fas fa-arrow-right" style="color: #B31942;"></i>
+                  </div>
+                </div>
+              </div>
+            </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Regional Highlights -->
+  <section class="py-5" style="background: linear-gradient(135deg, #f8f8f8 0%, #e8e8e8 100%);">
+    <div class="container">
+      <h2 class="text-center mb-5" style="font-family: 'Roboto Condensed', sans-serif; font-weight: 700; color: #0A3161;">
+        Regional Highlights
+      </h2>
+
+      <div class="row g-4">
+        <div class="col-md-6 col-lg-3">
+          <div class="highlight-card p-4 h-100 text-center">
+            <i class="fas fa-pound-sign fa-3x mb-3" style="color: #0A3161;"></i>
+            <h3 class="h5 mb-2">United Kingdom</h3>
+            <p class="text-muted mb-0">Fighting against excessive cycle lane expansion in London and major cities</p>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-3">
+          <div class="highlight-card p-4 h-100 text-center">
+            <i class="fas fa-snowflake fa-3x mb-3" style="color: #0A3161;"></i>
+            <h3 class="h5 mb-2">Canada</h3>
+            <p class="text-muted mb-0">Advocating for seasonal cycling infrastructure in harsh winter climates</p>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-3">
+          <div class="highlight-card p-4 h-100 text-center">
+            <i class="fas fa-sun fa-3x mb-3" style="color: #0A3161;"></i>
+            <h3 class="h5 mb-2">Australia</h3>
+            <p class="text-muted mb-0">Challenging unfair minimum passing distance laws on rural roads</p>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-3">
+          <div class="highlight-card p-4 h-100 text-center">
+            <i class="fas fa-car fa-3x mb-3" style="color: #0A3161;"></i>
+            <h3 class="h5 mb-2">Germany</h3>
+            <p class="text-muted mb-0">Protecting Autobahn freedom and opposing Green Party speed limits</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- US Chapters Cross-Link -->
+  <section class="py-5 bg-light">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-10">
+          <div class="card shadow-lg border-0">
+            <div class="card-body p-5 text-center">
+              <i class="fas fa-flag-usa fa-4x mb-4" style="color: #B31942;"></i>
+              <h2 class="mb-4" style="font-family: 'Roboto Condensed', sans-serif; font-weight: 700; color: #0A3161;">
+                Looking for US Chapters?
+              </h2>
+              <p style="color: #555; font-size: 1.2rem; line-height: 1.8; margin-bottom: 2rem;">
+                AARBAA was founded in the United States and maintains active chapters in all 50 states. With over 15,000 members nationwide, our US operations are the largest and most established part of our organization.
+              </p>
+              <a href="/chapters" class="btn btn-danger btn-lg px-5" style="border-radius: 50px;">
+                <i class="fas fa-map-marked-alt me-2"></i>
+                View US State Chapters
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Call to Action -->
+  <section class="py-5 bg-white">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-8 text-center">
+          <h2 class="mb-4" style="font-family: 'Roboto Condensed', sans-serif; font-weight: 700; color: #0A3161;">
+            Don't See Your Country?
+          </h2>
+          <p style="color: #555; font-size: 1.2rem; line-height: 1.8; margin-bottom: 2rem;">
+            AARBAA International is expanding globally. If your country isn't listed yet, help us bring balanced transportation advocacy to your nation. We provide resources, templates, and support for new international chapters.
+          </p>
+          <div class="d-flex gap-3 justify-content-center flex-wrap">
+            <a href="/contact" class="btn btn-danger btn-lg px-5" style="border-radius: 50px;">
+              Start an International Chapter
+            </a>
+            <a href="/about" class="btn btn-outline-primary btn-lg px-5" style="border-radius: 50px;">
+              Learn More About AARBAA
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</MainLayout>
+
+<style>
+  .stat-box {
+    transition: all 0.3s ease;
+  }
+
+  .stat-box:hover {
+    transform: scale(1.05);
+  }
+
+  .country-card-link {
+    text-decoration: none;
+    color: inherit;
+    display: block;
+    height: 100%;
+  }
+
+  .country-card {
+    background: white;
+    border-radius: 12px;
+    border: 2px solid #e8e8e8;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  }
+
+  .country-card:hover {
+    transform: translateY(-8px);
+    border-color: #B31942;
+    box-shadow: 0 8px 20px rgba(179, 25, 66, 0.2);
+  }
+
+  .country-card:hover .country-name {
+    color: #B31942;
+  }
+
+  .country-card:hover .fas.fa-arrow-right {
+    transform: translateX(5px);
+  }
+
+  .fas.fa-arrow-right {
+    transition: transform 0.3s ease;
+  }
+
+  .country-icon {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background-color: rgba(179, 25, 66, 0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+  }
+
+  .country-card:hover .country-icon {
+    background-color: #B31942;
+  }
+
+  .country-card:hover .country-icon i {
+    color: white !important;
+  }
+
+  .highlight-card {
+    background: white;
+    border-radius: 12px;
+    border: 2px solid #e8e8e8;
+    transition: all 0.3s ease;
+  }
+
+  .highlight-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 20px rgba(10, 49, 97, 0.15);
+    border-color: #0A3161;
+  }
+
+  @media (max-width: 768px) {
+    .stat-box h3 {
+      font-size: 2rem !important;
+    }
+  }
+</style>


### PR DESCRIPTION
Created comprehensive country pages for AARBAA's international expansion:
- United Kingdom (8,750 members, 47 chapters, 134 victories)
- Canada (6,420 members, 38 chapters, 97 victories)
- Australia (5,890 members, 28 chapters, 82 victories)
- Netherlands (3,240 members, 18 chapters, 47 victories)
- Germany (7,130 members, 34 chapters, 103 victories)

Each country page includes:
- Regional director contact information
- Member testimonials and ratings
- Featured articles and FAQs
- Upcoming events with detailed information
- Infrastructure victories and ongoing issues
- Local statistics (cycling fatalities, infrastructure miles, funding)
- Photo galleries with modal lightbox
- Contact forms with country pre-filled
- Full SEO optimization with JSON-LD structured data

Navigation updates:
- Added "International" dropdown menu with all 5 countries
- Country flags icons in dropdown for visual identification
- Links to country overview page

Interlinking improvements:
- State pages now link to international chapters
- Country pages link to US state chapters
- Cross-promotion between domestic and international presence

Technical features:
- Dynamic routing with getStaticPaths
- Pre-rendering for optimal performance
- Responsive Bootstrap 5 design
- Comprehensive schema.org markup for SEO
- Breadcrumb navigation
- Currency-aware formatting (GBP, CAD, AUD, EUR)

Files modified:
- src/data/countries.ts (new, comprehensive country data)
- src/pages/countries/[country].astro (new, dynamic country template)
- src/pages/countries/index.astro (new, countries listing page)
- src/layouts/MainLayout.astro (added International navigation dropdown)
- src/pages/chapters/[state].astro (added International interlinking)